### PR TITLE
検閲タグの個別化

### DIFF
--- a/app/controllers/censorings_controller.rb
+++ b/app/controllers/censorings_controller.rb
@@ -1,0 +1,20 @@
+class CensoringsController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    begin
+      Category.pluck(:name).each do |category_name|
+        if current_user.censoring?(category_name)
+          current_user.uncensor(category_name) if params[category_name] == '0'
+        else
+          current_user.censor(category_name) if params[category_name] == '1'
+        end
+      end
+      flash[:success] = '検閲カテゴリの設定に成功しました'
+    rescue => e
+      flash[:danger] = "検閲カテゴリの設定に失敗しました: #{e}"
+    ensure
+      redirect_to edit_user_registration_path(current_user)
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,23 @@ class UsersController < ApplicationController
     render 'show_follow'
   end
 
+  def censorings
+    begin
+      Category.pluck(:name).each do |category_name|
+        if current_user.censoring?(category_name)
+          current_user.uncensor(category_name) if params[category_name] == '0'
+        else
+          current_user.censor(category_name) if params[category_name] == '1'
+        end
+      end
+      flash[:success] = '検閲カテゴリの設定に成功しました'
+    rescue => e
+      flash[:danger] = "検閲カテゴリの設定に失敗しました: #{e}"
+    ensure
+      redirect_to edit_user_registration_path(current_user)
+    end
+  end
+
   private
 
     def friend_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,23 +29,6 @@ class UsersController < ApplicationController
     render 'show_follow'
   end
 
-  def censorings
-    begin
-      Category.pluck(:name).each do |category_name|
-        if current_user.censoring?(category_name)
-          current_user.uncensor(category_name) if params[category_name] == '0'
-        else
-          current_user.censor(category_name) if params[category_name] == '1'
-        end
-      end
-      flash[:success] = '検閲カテゴリの設定に成功しました'
-    rescue => e
-      flash[:danger] = "検閲カテゴリの設定に失敗しました: #{e}"
-    ensure
-      redirect_to edit_user_registration_path(current_user)
-    end
-  end
-
   private
 
     def friend_user

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,10 +1,12 @@
 module CategoriesHelper
-  def censored?(link)
-    names = link.categories.where(censored_by_default: true).pluck(:name)
-    if names.empty? #これもっとうまく書けるきがする
-      false
+  # 検閲されてるタグの名前を返す. ないなら空集合返ってくる
+  def censored_tags(link)
+    if user_signed_in?
+      link.categories.pluck(:name).select do |category|
+        current_user.censoring?(category)
+      end
     else
-      names
+      link.categories.where(censored_by_default: true).pluck(:name)
     end
   end
 end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,0 +1,11 @@
+class Preference < ApplicationRecord
+  belongs_to :user
+  belongs_to :category
+
+  validates :user, presence: true
+  validates :category, presence: true
+
+  # User can have multiple Prefences which express different meanings. (e.g. mute list and block list)
+  # Therefore, a pair of user and category doesn't have to be unique.
+  # validates_uniqueness_of :user_id, scope: :category_id
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,7 +141,7 @@ class User < ApplicationRecord
     end
 
     def set_default_censoring
-      Category.where(censored_by_default: false).each do |category|
+      Category.where(censored_by_default: true).each do |category|
         self.censor(category)
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,9 @@ class User < ApplicationRecord
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'origin_id', dependent: :destroy
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'destination_id', dependent: :destroy
 
+  has_many :censorings, class_name: 'Preference', dependent: :destroy
+  has_many :censored_categories, through: :censorings, source: :category
+
   # list nweets shown in timeline.
   def timeline
     Nweet.all # currently it is global! (since FF is not implemented)
@@ -85,6 +88,31 @@ class User < ApplicationRecord
 
   def follower?(other_user)
     self.followers.include?(other_user)
+  end
+
+  # censor, uncensor, censoring? can take both instances of String and Category
+  def censor(category)
+    if category.instance_of?(String)
+      category = Category.find_by(name: category)
+    end
+
+    self.censored_categories << category
+  end
+
+  def uncensor(category)
+    if category.instance_of?(String)
+      category = Category.find_by(name: category)
+    end
+
+    self.censorings.find_by(category_id: category.id).destroy
+  end
+
+  def censoring?(category)
+    if category.instance_of?(Category)
+      category = category.name
+    end
+
+    self.censored_categories.exists?(name: category)
   end
 
   def liked?(nweet)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   before_create :set_url_digest
+  after_create :set_default_censoring
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -134,7 +135,14 @@ class User < ApplicationRecord
   end
 
   private
+
     def set_url_digest
       self.url_digest = SecureRandom.alphanumeric
+    end
+
+    def set_default_censoring
+      Category.where(censored_by_default: false).each do |category|
+        self.censor(category)
+      end
     end
 end

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,6 +1,5 @@
 .mt-0.mb-2
-  / 真のタグ機能完成するまでの仮　R18Gと3Dだけいじれる
-  - ['R18G', '3D'].each do |category|
+  - Category.pluck(:name).each do |category|
     - if link.categories.exists?(name: category)
       span.badge.badge-tag.active.mx-1
         span.small = icon 'fas', 'hashtag'

--- a/app/views/cards/_horizontal.html.slim
+++ b/app/views/cards/_horizontal.html.slim
@@ -1,4 +1,5 @@
-- if tags = censored?(link)
+- tags = censored_tags(link)
+- if tags.any?
   .small.pb-1
     span.pr-1 = icon('fas', 'exclamation-triangle')
     - tags.each do |tag|
@@ -6,7 +7,7 @@
     span.collapse-button
       a href= "#collapseHorizontal#{link.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseHorizontal#{link.id}" 展開
 
-div id="collapseHorizontal#{link.id}" class="#{'collapse' if censored?(link)}"
+div id="collapseHorizontal#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do
     - if link.image?
       = image_tag link.image, class: 'card-img-top'

--- a/app/views/cards/_vertical.html.slim
+++ b/app/views/cards/_vertical.html.slim
@@ -1,4 +1,5 @@
-- if tags = censored?(link)
+- tags = censored_tags(link)
+- if tags.any?
   .small.pb-1
     span.pr-1 = icon('fas', 'exclamation-triangle')
     - tags.each do |tag|
@@ -6,7 +7,7 @@
     span.collapse-button
       a href= "#collapseVertical#{link.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseVertical#{link.id}" 展開
 
-div id="collapseVertical#{link.id}" class="#{'collapse' if censored?(link)}"
+div id="collapseVertical#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do
     .row.no-gutters.align-items-center
       - if link.image?

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -89,7 +89,7 @@
       p = link_to "twitterアカウントを登録", "/auth/twitter", class: "btn btn-twitter"
     h3 その他のオプション
     h5 検閲カテゴリ
-    = form_with url: censorings_user_path(current_user), method: :put, class: "form-group" do |f|
+    = form_with url: censoring_path(current_user), method: :put, class: "form-group" do |f|
       .form-group
         - Category.pluck(:name).each do |category_name|
           .form-check.form-check-inline

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -88,5 +88,13 @@
     - if current_user.twitter_screen_name.nil?
       p = link_to "twitterアカウントを登録", "/auth/twitter", class: "btn btn-twitter"
     h3 その他のオプション
+    h5 検閲カテゴリ
+    = form_with url: censorings_user_path(current_user), method: :put, class: "form-group" do |f|
+      .form-group
+        - Category.pluck(:name).each do |category_name|
+          .form-check.form-check-inline
+            = f.check_box "#{category_name}", {:checked => current_user.censoring?(category_name), class: 'form-check-input'}
+            label.form-check-label = category_name
+        = f.submit "検閲カテゴリを更新", class: 'btn btn-follow'
     p = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当にアカウントを削除しますか？" }, method: :delete, class: "btn btn-danger"
     = link_to "戻る", :back

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
     member do
       get :likes
       get :followers, :followees
-      put :censorings
     end
   end
 
@@ -22,5 +21,6 @@ Rails.application.routes.draw do
   resource :category, only: [:create, :destroy]
   resource :like, only: [:create, :destroy]
   resource :link, only: [:create]
+  resource :censoring, only: [:update]
   resource :relationship, only: [:create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     member do
       get :likes
       get :followers, :followees
+      put :censorings
     end
   end
 

--- a/db/migrate/20191106222131_create_preferences.rb
+++ b/db/migrate/20191106222131_create_preferences.rb
@@ -1,0 +1,10 @@
+class CreatePreferences < ActiveRecord::Migration[5.2]
+  def change
+    create_table :preferences do |t|
+      t.references :user, foreign_key: true
+      t.references :category, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191107072457_add_description_to_categories.rb
+++ b/db/migrate/20191107072457_add_description_to_categories.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :description, :string, limit: 200
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_222131) do
+ActiveRecord::Schema.define(version: 2019_11_07_072457) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 30, null: false
     t.boolean "censored_by_default", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "description", limit: 200
     t.index ["name"], name: "index_categories_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_01_164435) do
+ActiveRecord::Schema.define(version: 2019_11_06_222131) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 30, null: false
@@ -86,6 +86,15 @@ ActiveRecord::Schema.define(version: 2019_11_01_164435) do
     t.index ["user_id"], name: "index_nweets_on_user_id"
   end
 
+  create_table "preferences", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_preferences_on_category_id"
+    t.index ["user_id"], name: "index_preferences_on_user_id"
+  end
+
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "followee_id"
@@ -141,4 +150,6 @@ ActiveRecord::Schema.define(version: 2019_11_01_164435) do
   add_foreign_key "nweet_links", "links"
   add_foreign_key "nweet_links", "nweets"
   add_foreign_key "nweets", "users"
+  add_foreign_key "preferences", "categories"
+  add_foreign_key "preferences", "users"
 end

--- a/lib/tasks/category_task.rake
+++ b/lib/tasks/category_task.rake
@@ -1,0 +1,19 @@
+namespace :category_task do
+  desc "initialize categories"
+  task init: :environment do
+    Preference.destroy_all
+    Category.destroy_all
+
+    Category.create(name: 'R18G', description: '猟奇的・残酷な描写')
+    Category.create(name: '3D', description: '撮影された動画や画像')
+
+    Category.where(censored_by_default: true).each do |category|
+      puts "censoring #{category.name}..."
+      User.find_each do |user|
+        print "#{user.id} "
+        user.censored_categories << category
+      end
+      puts ""
+    end
+  end
+end

--- a/test/controllers/censorings_controller_test.rb
+++ b/test/controllers/censorings_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class CensoringsControllerTest < ActionDispatch::IntegrationTest
+  include Warden::Test::Helpers
+
+  def setup
+    Warden.test_mode!
+    @user = users(:chikuwa)
+  end
+
+  test "editing censoring require log in" do
+    put censoring_path, params: {'r18g': '0', '3d': '0'}
+    assert_redirected_to new_user_session_url
+
+    login_as(@user)
+    put censoring_path, params: {'r18g': '0', '3d': '0'}
+    assert_redirected_to edit_user_registration_path(@user) # とりあえず成功してるってことで……
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,3 @@
+r18g:
+  name: 'R18G'
+  censored_by_default: true # fixtures don't use callbacks

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,3 +1,11 @@
 r18g:
   name: 'R18G'
   censored_by_default: true # fixtures don't use callbacks
+
+three_d:
+  name: '3D'
+  censored_by_default: true
+
+kemo:
+  name: 'KEMO'
+  censored_by_default: false

--- a/test/fixtures/link_categories.yml
+++ b/test/fixtures/link_categories.yml
@@ -1,1 +1,7 @@
+kanikama_is_r18g:
+  link: kanikama
+  category: r18g
 
+kemo_is_kemo:
+  link: kemo
+  category: kemo

--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -1,1 +1,6 @@
+kanikama:
+  url: 'https://www.pixiv.net/artworks/59554738'
 
+kemo:
+  url: 'https://twitter.com/aoi_nishimata/status/831825876899635200'
+  title: 'あなたの…フレンズにしてください♪'

--- a/test/fixtures/nweet_links.yml
+++ b/test/fixtures/nweet_links.yml
@@ -1,0 +1,7 @@
+one:
+  nweet: r18g
+  link: kanikama
+
+two:
+  nweet: kemo
+  link: kemo

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -30,3 +30,15 @@ chirstmas:
   user: chikuwa
   url_digest: <%= SecureRandom.alphanumeric %>
   statement: '😢'
+
+r18g:
+  did_at: <%= 3.days.ago.utc %>
+  user: chikuwa
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: 'https://www.pixiv.net/artworks/59554738'
+
+kemo:
+  did_at: <%= 15.days.ago.utc %>
+  user: emiya
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: 'https://twitter.com/aoi_nishimata/status/831825876899635200'

--- a/test/integration/censoring_test.rb
+++ b/test/integration/censoring_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class CensoringTest < ActionDispatch::IntegrationTest
+  include Warden::Test::Helpers
+
+  def setup
+    Warden.test_mode!
+    @user = users(:chikuwa)
+  end
+
+  # censor by 'Category.censored_by_default' when not logged-in
+  test 'censoring test (for guest)' do
+    nweet = nweets(:r18g)
+    link = nweet.links.first
+    get nweet_path(nweet)
+    assert_select "a[href=?]", "#collapseVertical#{link.id}"
+
+    nweet = nweets(:kemo)
+    link = nweet.links.first
+    get nweet_path(nweet)
+    assert_select "a[href=?]", "#collapseVertical#{link.id}", false
+  end
+
+  test 'censoring test (for user)' do
+    login_as(@user)
+
+    nweet = nweets(:kemo)
+    link = nweet.links.first
+    get nweet_path(nweet)
+    assert_select "a[href=?]", "#collapseVertical#{link.id}", false
+
+    put censorings_user_path(@user), params: {"R18G": 1, "KEMO": 1}
+    get nweet_path(nweet)
+    assert_select "a[href=?]", "#collapseVertical#{link.id}"
+
+    nweet = nweets(:r18g)
+    link = nweet.links.first
+    get nweet_path(nweet)
+    assert_select "a[href=?]", "#collapseVertical#{link.id}"
+
+    put censorings_user_path(@user), params: {"R18G": "0", "KEMO": "0"}
+    get nweet_path(nweet)
+    assert_select "a[href=?]", "#collapseVertical#{link.id}", false
+  end
+end

--- a/test/integration/censoring_test.rb
+++ b/test/integration/censoring_test.rb
@@ -29,7 +29,7 @@ class CensoringTest < ActionDispatch::IntegrationTest
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseVertical#{link.id}", false
 
-    put censorings_user_path(@user), params: {"R18G": 1, "KEMO": 1}
+    put censoring_path(@user), params: {"R18G": 1, "KEMO": 1}
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseVertical#{link.id}"
 
@@ -38,7 +38,7 @@ class CensoringTest < ActionDispatch::IntegrationTest
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseVertical#{link.id}"
 
-    put censorings_user_path(@user), params: {"R18G": "0", "KEMO": "0"}
+    put censoring_path(@user), params: {"R18G": "0", "KEMO": "0"}
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseVertical#{link.id}", false
   end

--- a/test/models/preference_test.rb
+++ b/test/models/preference_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class PreferenceTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:chikuwa)
+    @category = categories(:r18g)
+  end
+
+  test "user and category have to be present, but don't have to be unique" do
+    preference = Preference.create(user: @user, category: @category)
+    assert preference.valid?
+
+    no_user_preference = Preference.new(category: @category)
+    assert_not no_user_preference.valid?
+
+    no_category_preference = Preference.new(user: @user)
+    assert_not no_category_preference.valid?
+
+    dup_preference = Preference.new(user: @user, category: @category)
+    assert dup_preference.valid?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -83,6 +83,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'create censoring when a user is created' do
     user = User.create(screen_name: "kaburanai", email: "kaburan@gmail.com", password: "hogehoge")
+    debugger
     assert user.censoring?('R18G')
     assert_not user.censoring?('KEMO')
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -80,4 +80,10 @@ class UserTest < ActiveSupport::TestCase
     assert notification.announce?
     assert_equal str, notification.statement
   end
+
+  test 'create censoring when a user is created' do
+    user = User.create(screen_name: "kaburanai", email: "kaburan@gmail.com", password: "hogehoge")
+    assert user.censoring?('R18G')
+    assert_not user.censoring?('KEMO')
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -62,6 +62,18 @@ class UserTest < ActiveSupport::TestCase
     assert_not @new_user.followee?(@user)
   end
 
+  test 'should censor and uncensor category' do
+    category = categories(:r18g)
+    @user.censor(category)
+    assert @user.censoring?(category.name)
+
+    @user.uncensor(category)
+    assert_not @user.censoring?(category.name)
+
+    @user.censor(category.name)
+    assert @user.censoring?(category)
+  end
+
   test 'can announce' do
     str = '<h6>寄付のお願い</h6><p>詳細は<a href="https://google.com">こちら</a></p>'
     notification = @user.announce(str)


### PR DESCRIPTION
ユーザーごとに検閲（「展開」押さないと表示されないようになる）されるオカズが設定できるようになった
検閲の判定基準が以下のように変わったので、デプロイ時には `category_task:init` 必要

- Preference: UserとCategoryの中間テーブル
- UserはPreference(`User.censorings`)経由でCategory(`User.censored_categories`)を持つ
- `User.censored_categories.exists?(category)` で検閲するかどうか決定
- 非ログイン時や新規ユーザーに検閲されるかどうかは`Category.censored_by_default`の値で決まる
- あとはここまで仕組み作っておけばカテゴリの数増やしたりPreferenceもう1つ持たせてお気に入りカテゴリ設定したりできると思う

ここまで書いてて気づいたけど新規ユーザーに対する処理書いてなかった