### PR TITLE
新規登録画面表示できない不具合修正

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -19,7 +19,14 @@ module UsersHelper
 
   # さらにicon_urlをimageタグを返してくれる
   def icon_for(user, size: 80, htmlclass: 'usericon')
-    image_tag(icon_url(user, size), alt: user.handle_name, size: size.to_s, class: htmlclass, id: "usericon-#{user.id}")
+    if user.present?
+      alt = user.handle_name
+      id = "usericon-#{user.id}"
+    else
+      alt = ''
+      id = "usericon-default"
+    end
+    image_tag(icon_url(user, size), alt: alt, size: size.to_s, class: htmlclass, id: id)
   end
 
   def current_user?(user)

--- a/test/integration/devise_test.rb
+++ b/test/integration/devise_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class DeviseTest < ActionDispatch::IntegrationTest
+  include Warden::Test::Helpers
+
+  def setup
+    Warden.test_mode!
+    @user = users(:chikuwa)
+  end
+
+  test 'should show log-in' do
+    get new_user_session_url
+    assert_response :success
+  end
+
+  test 'should show sign-up' do
+    get new_user_registration_url
+    assert_response :success
+  end
+
+  test 'should show user edit' do
+    get edit_user_registration_url
+    assert_response 302
+
+    login_as(@user)
+    get edit_user_registration_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
原因はリライトしたicon_forでユーザーがまだ存在しないときの挙動とか考えてなかったことです

deviseの作ったページのテスト全然書いてなかったから追加した