### PR TITLE
did_atがnweetボタン押したタイミングになるように修正 #5

### DIFF
--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -3,7 +3,7 @@ class NweetsController < ApplicationController
   before_action :correct_user, only: [:destroy, :update]
 
   def create
-    @nweet = current_user.nweets.build(new_nweet_params)
+    @nweet = current_user.nweets.build(did_at: Time.zone.now)
     if @nweet.save # edit に移すべきかも
       redirect_to root_url(success: true, url_digest: @nweet.url_digest)
       tweet if current_user.autotweet_enabled
@@ -39,10 +39,6 @@ class NweetsController < ApplicationController
 
   private
     # strong parameters
-    def new_nweet_params
-      params.require(:nweet).permit(:did_at)
-    end
-
     def edit_nweet_params
       params.require(:nweet).permit(:statement)
     end

--- a/app/views/nweets/_create_form.html.slim
+++ b/app/views/nweets/_create_form.html.slim
@@ -1,5 +1,4 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
   /= render 'shared/error_messages', object: f.object
   .field
-    = hidden_field_tag 'nweet[did_at]', Time.zone.now
     = f.submit "#nuita!", class: "btn btn-nuita btn-block", id: "button-nuita"


### PR DESCRIPTION
## issue

https://github.com/nuita/nuita/issues/5

## comment

nweet作るのにいちいち
`nweets.build(did_at: Time.zone.now)`
ってやるのダサいからモデル側でdid_at入れるような感じにしようかと思ったけどテストとかvalidationもいじるはめになったからやめた

collaborator権限ください！！！