### PR TITLE
ヌイート中のハッシュタグに相当するカテゴリが存在しないときに自動生成する機能を削除

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -22,10 +22,7 @@ class Link < ApplicationRecord
 
   def set_category(name)
     name.upcase!
-    unless c = Category.find_by(name: name)
-      c = Category.create(name: name)
-    end
-    unless categories.exists?(id: c.id)
+    if c = Category.find_by(name: name)
       self.categories << c
     end
   end

--- a/lib/tasks/category_task.rake
+++ b/lib/tasks/category_task.rake
@@ -16,4 +16,9 @@ namespace :category_task do
       puts ""
     end
   end
+
+  desc "remove unnecessary(not censored by default) categories"
+  task clean: :environment do
+    Category.where(censored_by_default: false).destroy_all
+  end
 end

--- a/test/models/nweet_test.rb
+++ b/test/models/nweet_test.rb
@@ -81,14 +81,11 @@ class NweetTest < ActiveSupport::TestCase
     assert_equal link, nweet_again.links.first
   end
 
-  test 'tags in nweet must be generated as category' do
-    str = "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=75609372 #R18G #2D"
+  test 'tags in nweet must NOT be generated as category' do
+    str = "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=75609372 #pixiv"
     nweet = @user.nweets.create(did_at: Time.zone.now, statement: str)
     link = nweet.links.first
 
-    assert link.categories.exists?(name: 'R18G', censored_by_default: true)
-    assert link.categories.exists?(name: '2D', censored_by_default: false)
-    # 将来的に実装したい
-    #assert_equal "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=75609372", nweet.statement
+    assert_not link.categories.exists?(name: 'pixiv')
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -83,7 +83,7 @@ class UserTest < ActiveSupport::TestCase
 
   test 'create censoring when a user is created' do
     user = User.create(screen_name: "kaburanai", email: "kaburan@gmail.com", password: "hogehoge")
-    debugger
+
     assert user.censoring?('R18G')
     assert_not user.censoring?('KEMO')
   end


### PR DESCRIPTION
ヌイート中に「#R18G」とか入れるとタグ付けされる機能をこっそり実装していたんですが、勝手にカテゴリ作る機能も実装していたのを忘れていた

UI的にカテゴリ乱立するとしんどくなるので、とりあえずカテゴリの新規作成機能は削除、ただし既存のカテゴリに対してはタグ付け機能継続

`category_task:clean` で不要なカテゴリ（デフォルトで検閲機能ついてないやつ）を削除できるようになったので、本番で動かす