### PR TITLE
Fetch melonbooks mk2

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -128,7 +128,7 @@ class Link < ApplicationRecord
 
         proxy_url
       when /melonbooks/
-        str = page.css('//meta[name="twitter:image"]/@content').first.to_s.sub(/&c=1/, '')
+        str = page.css('//meta[property="og:image"]/@content').first.to_s.sub(/&c=1/, '')
       else
         page.css('//meta[property="og:image"]/@content').first.to_s
       end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -38,8 +38,8 @@ class Link < ApplicationRecord
       when /nijie/
         url.sub!(/sp.nijie/, 'nijie')
         url.sub(/view_popup/, 'view')
-      when /melon/
-        url + '&adult_view=1'
+      when /melonbooks.co.jp\/detail\/detail.php\?product_id=(\d+)/
+        'https://www.melonbooks.co.jp/detail/detail.php?product_id=' + $1 + '&adult_view=1'
       when /komiflo\.com(?:\/#!)?\/comics\/(\d+)/
         'https://komiflo.com/comics/' + $1
       when /pixiv\.net\/member_illust.php?.*illust_id=(\d+)/

--- a/lib/tasks/link_task.rake
+++ b/lib/tasks/link_task.rake
@@ -1,0 +1,9 @@
+namespace :link_task do
+  desc "refetch all melonbook items"
+  task refetch_melonbooks: :environment do
+    Link.where("url LIKE '%melonbooks%'").find_each do |link|
+      link.refetch
+      p link
+    end
+  end
+end


### PR DESCRIPTION
メタタグが変わっていたらしく画像をしばらく読み取れていなかった

ついでにURL正規化を厳密にしたり ```rake link_task:refetch_melonbooks``` でデータ再取得できるようにしたりした

感想；リンクカード周りの現在の処理はすごくゴミ