### PR TITLE
クリスマス関連の表示を除去

### DIFF
--- a/app/controllers/christmas_controller.rb
+++ b/app/controllers/christmas_controller.rb
@@ -1,7 +1,4 @@
 class ChristmasController < ApplicationController
   def show
   end
-
-  def about
-  end
 end

--- a/app/views/christmas/about.html.slim
+++ b/app/views/christmas/about.html.slim
@@ -1,2 +1,0 @@
-h1 Christmas#about
-p Find me in app/views/christmas/about.html.slim

--- a/app/views/christmas/show.html.slim
+++ b/app/views/christmas/show.html.slim
@@ -2,6 +2,9 @@
 - provide(:custom_header, 'christmas_header')
 
 .container.not-so-jumbo.wider-margintop
+  .alert.alert-warning.p-1.mb-2
+    = icon 'far', 'calendar-alt'
+    span.pl-2 このイベントは2019年12月25日に終了しました。
   .christmas-jumbotron.col.pt-0.pb-2
     = image_tag 'christmas/logo_ac.png', alt: 'Nuita Advent Calendar', class: 'img-fluid'
     h6.font-weight-bold あなたの進捗状況

--- a/app/views/layouts/_user_header.html.slim
+++ b/app/views/layouts/_user_header.html.slim
@@ -20,5 +20,4 @@ ul.nav.navbar-nav.mx-auto.navbar-center
         .dropdown-item = link_to current_user.handle_name, user_path(current_user), class: 'nav-link'
         .dropdown-item = link_to 'いいねした投稿', likes_user_path(current_user), class: 'nav-link'
         .dropdown-item = link_to 'プロフィール変更', edit_user_registration_path, class: 'nav-link'
-        .dropdown-item.nav-item-christmas = link_to 'Nuita Advent Calendar', christmas_path, class: 'nav-link'
         .dropdown-item = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link'

--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -16,7 +16,7 @@ li.nweet id="nweet#{nweet.url_digest}" class="cb-#{nweet.user.has_christmas_badg
         span.time = time_ago_in_japanese(nweet.did_at)
         | に射精しました
         - if nweet.user.has_christmas_badge?
-          span.christmas-badge-icon
+          = link_to '', christmas_path, class: 'christmas-badge-icon'
         - else
           | 。
       - if nweet.links.any?

--- a/app/views/pages/_recommend.html.slim
+++ b/app/views/pages/_recommend.html.slim
@@ -1,6 +1,4 @@
 section.side-section
-  - if user_signed_in?
-    = render 'christmas/calendar', user: current_user, detailed: false
   h5.section-title
     | ランダムえっち
     button#buttonRenewRecommend.btn.btn-sm.btn-outline-secondary.btn-brandcolor-hover.py-0.px-1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
   get '/links/recommend', :to=> 'links#recommend'
 
   get '/christmas', :to => 'christmas#show', as: 'christmas'
-  get '/christmas/about', :to => 'christmas#about'
 
   resources :users, except: [:index], param: :url_digest do
     member do

--- a/test/controllers/christmas_controller_test.rb
+++ b/test/controllers/christmas_controller_test.rb
@@ -5,10 +5,4 @@ class ChristmasControllerTest < ActionDispatch::IntegrationTest
     get christmas_url
     assert_response :success
   end
-
-  test "should get about" do
-    get christmas_about_url
-    assert_response :success
-  end
-
 end


### PR DESCRIPTION
本当はStamp関連のコードとか全部消すつもりでいたけど、
1月31日までは（バッジの有無が妥当かとか確認するために）アドベントカレンダー見れるようにしたからあんま消えなかった

- ホーム画面でのアドベントカレンダーの表示廃止
- ヘッダーの右メニューでのアドベントカレンダーへのリンク廃止

くらい