### PR TITLE
スクロールしたあとのいいねボタン、フォローボタンにJS紐付いてなかったので修正

### DIFF
--- a/app/javascript/packs/follow_icon.ts
+++ b/app/javascript/packs/follow_icon.ts
@@ -1,4 +1,4 @@
-document.addEventListener('turbolinks:load', () => {
+export function setFollowIcons(){
   document.querySelectorAll('.follow-icon-link').forEach((a:Element) => {
     a.addEventListener('ajax:success',() => {
       var span = a.firstElementChild;
@@ -22,4 +22,8 @@ document.addEventListener('turbolinks:load', () => {
       span.classList.toggle('unfollowable');
     });
   });
+};
+
+document.addEventListener('turbolinks:load', () => {
+  setFollowIcons();
 });

--- a/app/javascript/packs/nweets.ts
+++ b/app/javascript/packs/nweets.ts
@@ -1,6 +1,4 @@
-// いいねのajax処理
-
-document.addEventListener('turbolinks:load', function(){
+export function setLikeButtons(){
   document.querySelectorAll('.like-btn').forEach(function(div){
     div.addEventListener('ajax:success', function(){
       var anchor = <HTMLElement>div.firstElementChild;
@@ -10,32 +8,21 @@ document.addEventListener('turbolinks:load', function(){
       // var likeNumElement = <HTMLElement>anchor.childNodes[1];
       anchor.classList.toggle('liked');
 
-      // var likeCount:number;
-      // if(likeNumElement.innerText){
-      //   likeCount = parseInt(likeNumElement.innerText);
-      // }else{
-      //   likeCount = 0;
-      // }
-
       if(icon.classList.contains('fas')){
         icon.classList.replace('fas', 'far');
         anchor.setAttribute('data-method', 'post');
         outerLatestLikedTime.classList.remove('d-none');
         likeFlash.innerText = '';
-        // likeCount--;
-        // if(likeCount){
-        //   likeNumElement.innerText = likeCount.toString();
-        // }else{
-        //   likeNumElement.innerText = "";
-        // }
       }else{
         icon.classList.replace('far', 'fas');
         anchor.setAttribute('data-method', 'delete');
         likeFlash.innerText = "「いいね」しました！";
         outerLatestLikedTime.classList.add('d-none');
-        // likeCount++;
-        // likeNumElement.innerText = likeCount.toString();
       }
     })
   });
+};
+
+document.addEventListener('turbolinks:load', function(){
+  setLikeButtons();
 });

--- a/app/javascript/packs/pagination.ts
+++ b/app/javascript/packs/pagination.ts
@@ -1,3 +1,6 @@
+import {setFollowIcons} from './follow_icon';
+import {setLikeButtons} from './nweets';
+
 document.addEventListener('turbolinks:load', function(){
   let paginateContainer = document.getElementById('willPaginateContainer');
 
@@ -40,6 +43,8 @@ document.addEventListener('turbolinks:load', function(){
           });
         }
       }
+      setFollowIcons();
+      setLikeButtons();
     }, observerOptions);
 
     observer.observe(document.querySelector('#willPaginateContainer'));


### PR DESCRIPTION
`addEventListener(turbolinks:load)` でいいねボタンの動作をDOMに紐付ける
-> `insertAdjacentHTML()` でfetchしてきたヌイート挿入する
-> 挿入されたヌイートにはいいねボタンとかの動作紐付けられてない

みたいなことだと思う
JSかなり雑なのでもっと賢く早くしたい……