### PR TITLE
オカズの画像サイズを覚えておいてimgタグ上に残す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'faker'
 
 gem "nokogiri", ">= 1.10.4"
 gem 'valid_url'
+gem 'fastimage'
 
 gem 'mysql2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     execjs (2.7.0)
     faker (2.4.0)
       i18n (~> 1.6.0)
+    fastimage (2.1.7)
     ffi (1.11.1)
     fog-aws (3.5.2)
       fog-core (~> 2.1)
@@ -377,6 +378,7 @@ DEPENDENCIES
   devise (>= 4.7.1)
   ed25519
   faker
+  fastimage
   fog-aws
   font-awesome-sass (~> 5.9.0)
   google-analytics-rails

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -67,6 +67,7 @@ class Link < ApplicationRecord
           self.title = parse_title(page)
           self.description = parse_description(page)
           self.image = parse_image(page)
+          set_imagesizes
         rescue
           self.title = self.url
         end
@@ -153,6 +154,14 @@ class Link < ApplicationRecord
         self.image = 'https://t.komiflo.com/564_mobile_large_3x/' + json['content']['named_imgs']['cover']['filename'];
       rescue
         self.title = self.url
+      end
+    end
+
+    def set_imagesizes
+      begin
+        self.image_width, self.image_height = FastImage.size(self.image)
+      rescue
+        logger.debug('failed to set image sizes in #{link.url}')
       end
     end
 end

--- a/app/views/cards/_horizontal.html.slim
+++ b/app/views/cards/_horizontal.html.slim
@@ -10,7 +10,7 @@
 div id="collapseHorizontal#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do
     - if link.image?
-      img.card-img-top loading = 'lazy' src = link.image
+      img.card-img-top.h-100 loading='lazy' src = link.image height = link&.image_height width = link&.image_width
     .card-body
       h5.card-title = link.title
       p.card-text = link.description

--- a/app/views/cards/_vertical.html.slim
+++ b/app/views/cards/_vertical.html.slim
@@ -12,7 +12,7 @@ div id="collapseVertical#{link.id}" class="#{'collapse' if tags.any?}"
     .row.no-gutters.align-items-center
       - if link.image?
         .col-md-6.p-0
-          img.card-img loading = 'lazy' src = link.image
+          img.card-img.h-100 loading='lazy' src = link.image width=link&.image_width height = link&.image_height
       .col.p-0
         .card-body
           h5.card-title = link.title

--- a/db/migrate/20200117162634_add_image_sizes_to_links.rb
+++ b/db/migrate/20200117162634_add_image_sizes_to_links.rb
@@ -1,0 +1,6 @@
+class AddImageSizesToLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :links, :image_width, :integer
+    add_column :links, :image_height, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_08_010050) do
+ActiveRecord::Schema.define(version: 2020_01_17_162634) do
 
   create_table "badges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2019_12_08_010050) do
     t.index ["name"], name: "index_categories_on_name", unique: true
   end
 
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "nweet_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -57,14 +57,16 @@ ActiveRecord::Schema.define(version: 2019_12_08_010050) do
     t.index ["link_id"], name: "index_link_categories_on_link_id"
   end
 
-  create_table "links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.text "title", limit: 255
-    t.text "description"
+  create_table "links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+    t.text "title"
+    t.text "description", limit: 16777215
     t.string "image"
     t.string "card"
     t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "image_width"
+    t.integer "image_height"
     t.index ["url"], name: "index_links_on_url", unique: true
   end
 
@@ -81,7 +83,7 @@ ActiveRecord::Schema.define(version: 2019_12_08_010050) do
     t.index ["destination_id"], name: "index_notifications_on_destination_id"
   end
 
-  create_table "nweet_links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "nweet_links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "nweet_id"
     t.bigint "link_id"
     t.datetime "created_at", null: false
@@ -90,12 +92,12 @@ ActiveRecord::Schema.define(version: 2019_12_08_010050) do
     t.index ["nweet_id"], name: "index_nweet_links_on_nweet_id"
   end
 
-  create_table "nweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "nweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.datetime "did_at"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "statement", limit: 255
+    t.text "statement"
     t.string "url_digest"
     t.datetime "latest_liked_time"
     t.index ["url_digest"], name: "index_nweets_on_url_digest", unique: true
@@ -135,7 +137,7 @@ ActiveRecord::Schema.define(version: 2019_12_08_010050) do
     t.index ["user_id"], name: "index_stamps_on_user_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/lib/tasks/link_task.rake
+++ b/lib/tasks/link_task.rake
@@ -7,10 +7,24 @@ namespace :link_task do
     end
   end
 
+  desc "refetch all pixiv items"
   task refetch_pixiv: :environment do
     Link.where("url LIKE '%pixiv%'").find_each do |link|
       link.refetch
       p link
+    end
+  end
+
+  desc "refetch all links. Use when there the URL columns are same"
+  task refetch_all: :environment do
+    Link.all.find_each do |link|
+      begin
+        link.refetch
+      rescue => e
+        puts e
+      ensure
+        p link
+      end
     end
   end
 end

--- a/lib/tasks/nweet_task.rake
+++ b/lib/tasks/nweet_task.rake
@@ -9,10 +9,16 @@ namespace :nweet_task do
     end
   end
 
-  desc 'Refresh (and create) links on existing nweets'
+  desc 'Refresh (and create) links on existing nweets. Use when there are changes in URL columns'
   task :refresh_link => :environment do
-    Nweet.all.each do |nweet|
-      nweet.create_link
+    Nweet.all.find_each do |nweet|
+      begin
+        nweet.create_link
+      rescue => e
+        puts e
+      ensure
+        p nweet.links.first
+      end
     end
   end
 

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -53,6 +53,8 @@ class LinkTest < ActiveSupport::TestCase
     @link = Link.create(url: url)
 
     assert_equal 'https://pic.nijie.net/05/nijie_picture/3965_20190710041444_0.png', @link.image
+    assert_equal 1764, @link.image_width
+    assert_equal 1876, @link.image_height
   end
 
   test 'fetch pixiv correctly' do


### PR DESCRIPTION
オカズの画像サイズをURL取得時に確認→保存してimgタグの要素として表示
されるようになった。Nuita高速化活動の一環

`Link.image_width` = 画像横幅, `Link.image_height` = 画像縦幅

`rails task link_task:refetch_all`とかで既存画像のも大きさ取り直してこれるはずだけど、
一応幅ない場合も許容するようにviewとか書いてあります