### PR TITLE
オカズの公開範囲を投稿時に限定できるようにする

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -204,8 +204,8 @@ body{
   }
 }
 
-  .wider-margintop{
-  margin-top: 30px;
+.wider-margintop{
+  margin-top: 30px !important;
 }
 
 .btn.btn-unfollow{
@@ -248,6 +248,10 @@ body{
     color: white;
     background-color: $brand-color-light;
   }
+}
+
+.wider-marginbottom{
+  margin-bottom: 20px !important;
 }
 
 /* show user */
@@ -652,8 +656,8 @@ body{
 
 .btn.btn-block.btn-nuita {
   font-size: larger;
-  margin: 30px auto;
-  padding: 10px 30px 10px 30px;
+  margin: 10px auto;
+  padding: 10px 30px;
   border-radius: 10px;
   text-decoration: none;
   background-color: $brand-color;/*ボタン色*/
@@ -692,8 +696,8 @@ body{
 }
 
 /* edit */
-.statement {
-  margin: 10px auto;
+.statement-textbox {
+  margin: 0.125rem auto;
 	border: 1px solid $brand-color-light;
 	border-radius: 10px;
 	width: 100%;
@@ -706,7 +710,7 @@ body{
 }
 
 .statement-label {
-
+  font-size: small;
 }
 
 .like-color{

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -139,13 +139,6 @@ $contribution-color-more: rgb(25, 97, 39);
   }
 }
 
-@media screen and (max-width: 768px){
-  .nuita-form{
-    width: 95%;
-    margin: 0 auto;
-  }
-}
-
 body{
   padding-top: 48px;
   font-family: "Questrial", sans-serif;
@@ -697,6 +690,18 @@ a.tag-link{
 	border: 1px solid $brand-color-light;
 	border-radius: 10px;
 	width: 100%;
+  resize: none;
+
+  &:focus {
+    border: 2px solid $brand-color-light;
+    outline: 0;
+  }
+}
+
+.nuita-selectbox {
+  margin: auto;
+  border: 1px solid $brand-color-light;
+  border-radius: 10px;
   resize: none;
 
   &:focus {

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -389,21 +389,17 @@ body{
   border-radius: 0.3rem;
 }
 
-.badge-tag{
-  background-color: #fcfcfc;
-  border: 1px solid $brand-color;
-  color: $brand-color;
-  a{
-    color: inherit;
+a.tag-link{
+  .badge-tag{
+    background-color: #fcfcfc;
+    border: 1px solid $brand-color;
+    color: $brand-color;
     text-decoration: none;
   }
-}
 
-.badge-tag.active{
-  background-color: $brand-color;
-  color: #fff;
-  a{
-    color: inherit;
+  .badge-tag.active{
+    background-color: $brand-color;
+    color: #fff;
     text-decoration: none;
 
     .delete_icon{

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -382,7 +382,7 @@ body{
   border-radius: 0.3rem;
 }
 
-a.tag-link{
+.tag-link{
   .badge-tag{
     background-color: #fcfcfc;
     border: 1px solid $brand-color;
@@ -973,4 +973,14 @@ table.table-contribution.detailed-true{
 
 .x-small{
   font-size: x-small;
+}
+
+button{
+  background: transparent;
+  padding: 0;
+  border: none;
+}
+
+button:focus:not(.focus-visible) {
+  outline: none;
 }

--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -12,7 +12,7 @@ class NweetsController < ApplicationController
     end
   end
 
-  def create
+  def create 
     @nweet = current_user.nweets.build(new_nweet_params)
     if @nweet.save # edit に移すべきかも
       flash[:success] = 'ヌイートを投稿しました！'
@@ -55,7 +55,7 @@ class NweetsController < ApplicationController
   private
     # strong parameters
     def new_nweet_params
-      params.require(:nweet).permit(:statement, :did_at)
+      params.require(:nweet).permit(:statement, :did_at, :privacy)
     end
 
     def edit_nweet_params

--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -16,6 +16,9 @@ class NweetsController < ApplicationController
     @nweet = current_user.nweets.build(new_nweet_params)
     if @nweet.save # edit に移すべきかも
       flash[:success] = 'ヌイートを投稿しました！'
+      if @nweet.links.any?
+        set_categories(@nweet.links.first)
+      end
       tweet if current_user.autotweet_enabled
     else
       flash[:danger] = @nweet.errors.full_messages
@@ -36,6 +39,7 @@ class NweetsController < ApplicationController
     redirect_to root_url
   end
 
+  # obsolete
   def update
     @nweet = Nweet.find_by(url_digest: params[:url_digest])
 
@@ -61,5 +65,12 @@ class NweetsController < ApplicationController
     def correct_user
       @nweet = current_user.nweets.find_by(url_digest: params[:url_digest])
       redirect_to root_url if @nweet.nil?
+    end
+
+    def set_categories(link)
+      # 正直カテゴリーの中身mass assignmentされても何の脆弱性もないたぶん
+      params.permit(categories: {}).to_hash["categories"].each do |category_name, value|
+        link.set_category(category_name) if value == '1'
+      end
     end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,7 @@
 class PagesController < ApplicationController
   def home
     if user_signed_in?
-      if params[:success] == 'true'
-        @nweet = Nweet.find_by(url_digest: params[:url_digest])
-      else
-        @nweet = current_user.nweets.build
-      end
+      @nweet = current_user.nweets.build
       @feed_items = current_user.timeline.paginate(page: params[:page])
       @timeline = true
 

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -9,4 +9,20 @@ module CategoriesHelper
       link.categories.where(censored_by_default: true).pluck(:name)
     end
   end
+
+  def category_method(is_existing)
+    if is_existing
+      :delete
+    else
+      :post
+    end
+  end
+
+  def category_icon(is_existing)
+    if is_existing
+      "times"
+    else
+      "plus"
+    end
+  end
 end

--- a/app/helpers/nweets_helper.rb
+++ b/app/helpers/nweets_helper.rb
@@ -24,4 +24,15 @@ module NweetsHelper
       nil
     end
   end
+
+  def link_visible?(nweet)
+    case nweet.privacy.to_sym
+    when :to_everyone
+      true
+    when :to_followers
+      current_user && followee_or_self?(nweet.user)
+    when :to_author_only
+      current_user && current_user == nweet.user
+    end
+  end
 end

--- a/app/javascript/packs/categories.ts
+++ b/app/javascript/packs/categories.ts
@@ -1,0 +1,22 @@
+let setIndividualCategoryButton = (event:Event) => {
+  let a = <HTMLElement>event.currentTarget;
+
+  let badge = <HTMLElement>a.firstChild;
+  let i = <HTMLElement>badge.childNodes[2].firstChild;
+
+  if(a.getAttribute('data-method') == 'post'){
+    a.setAttribute('data-method', 'delete');
+    i.classList.replace('fa-plus', 'fa-times');
+    badge.classList.add('active');
+  }else{
+    a.setAttribute('data-method', 'post');
+    i.classList.replace('fa-times', 'fa-plus');
+    badge.classList.remove('active');
+  }
+}
+
+export function setCategoryButtons(){
+  document.querySelectorAll('.tag-link').forEach(function(div){
+    div.addEventListener('ajax:success', setIndividualCategoryButton);
+  });
+};

--- a/app/javascript/packs/categories.ts
+++ b/app/javascript/packs/categories.ts
@@ -1,3 +1,4 @@
+// 既に投稿されたオカズにタグつけるやつ (category#createとかに送る)
 let setIndividualCategoryButton = (event:Event) => {
   let a = <HTMLElement>event.currentTarget;
 
@@ -15,8 +16,34 @@ let setIndividualCategoryButton = (event:Event) => {
   }
 }
 
+// 新しく投稿するときにタグつけるやつ (JSでhidden_fieldの値変える)
+let setIndividualToggleTagButton = (event: Event) => {
+  let a = <HTMLElement>event.currentTarget;
+  let field = <HTMLElement>a.lastChild;
+
+  let n = parseInt(field.getAttribute('value'));
+  field.setAttribute('value', (1 - n).toString());
+  console.log(1 - n);
+
+  let badge = <HTMLElement>a.firstChild;
+  let i = <HTMLElement>badge.childNodes[2].firstChild;
+
+  if(i.classList.contains('fa-plus')){
+    i.classList.replace('fa-plus', 'fa-times');
+  }else{
+    i.classList.replace('fa-times', 'fa-plus');
+  }
+
+  badge.classList.toggle('active');
+};
+
+
 export function setCategoryButtons(){
-  document.querySelectorAll('.tag-link').forEach(function(div){
+  document.querySelectorAll('.nweet-tag-link').forEach(function(div){
     div.addEventListener('ajax:success', setIndividualCategoryButton);
+  });
+
+  document.querySelectorAll('.toggle-tag-link').forEach(function(div){
+    div.addEventListener('click', setIndividualToggleTagButton);
   });
 };

--- a/app/javascript/packs/pagination.ts
+++ b/app/javascript/packs/pagination.ts
@@ -1,5 +1,6 @@
 import {setFollowIcons} from './follow_icon';
 import {setLikeButtons} from './nweets';
+import {setCategoryButtons} from './categories';
 
 document.addEventListener('turbolinks:load', function(){
   let paginateContainer = document.getElementById('willPaginateContainer');
@@ -51,6 +52,7 @@ document.addEventListener('turbolinks:load', function(){
       }
       setFollowIcons();
       setLikeButtons();
+      setCategoryButtons();
 
       isLoading = false;
     }, observerOptions);
@@ -58,6 +60,7 @@ document.addEventListener('turbolinks:load', function(){
     observer.observe(document.querySelector('#willPaginateContainer'));
   }else{
     setFollowIcons();
-    setLikeButtons();    
+    setLikeButtons();
+    setCategoryButtons();
   }
 });

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -21,8 +21,7 @@ class Link < ApplicationRecord
   end
 
   def set_category(name)
-    name.upcase!
-    if c = Category.find_by(name: name)
+    if c = Category.find_by(name: name.upcase)
       self.categories << c
     end
   end

--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -1,6 +1,8 @@
 require 'uri'
 
 class Nweet < ApplicationRecord
+  enum privacy: [:public, :follower, :friend, :private]
+
   before_create :set_url_digest
 
   # statementはeditで編集されるのでafter_createではだめ

--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -1,7 +1,7 @@
 require 'uri'
 
 class Nweet < ApplicationRecord
-  enum privacy: [:public, :follower, :friend, :private]
+  enum privacy: [:to_everyone, :to_followers, :to_friends, :to_author_only]
 
   before_create :set_url_digest
 

--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -1,7 +1,8 @@
 require 'uri'
 
 class Nweet < ApplicationRecord
-  enum privacy: [:to_everyone, :to_followers, :to_friends, :to_author_only]
+  enum privacy: {to_everyone: 0, to_followers: 1, to_author_only: 3}
+  # to_friends: 2 is not used for now
 
   before_create :set_url_digest
 

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,14 +1,8 @@
 .mt-0.mb-2
   - Category.pluck(:name).each do |category|
-    - if link.categories.exists?(name: category)
-      span.badge.badge-tag.active.mx-1
+    - is_link_categorized = link.categories.exists?(name: category)
+    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), class: 'tag-link' do
+      span class="badge badge-tag mx-1 #{'active' if is_link_categorized = link.categories.exists?(name: category)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = category
-        = link_to category_path(link_id: link.id, category_name: category), method: :delete do
-          span.small.delete_icon = icon 'fas', 'times'
-    - else
-      span.badge.badge-tag.mx-1
-        span.small = icon 'fas', 'hashtag'
-        span.pr-1 = category
-        = link_to category_path(link_id: link.id, category_name: category), method: :post do
-          span.small.delete_icon = icon 'fas', 'plus'
+        span.small.delete_icon = icon 'fas', category_icon(is_link_categorized)

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,7 +1,7 @@
 .mt-0.mb-2
   - Category.pluck(:name).each do |category|
     - is_link_categorized = link.categories.exists?(name: category)
-    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), class: 'tag-link' do
+    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), remote: true, class: 'tag-link' do
       span class="badge badge-tag mx-1 #{'active' if is_link_categorized = link.categories.exists?(name: category)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = category

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,7 +1,7 @@
 .mt-0.mb-2
   - Category.pluck(:name).each do |category|
     - is_link_categorized = link.categories.exists?(name: category)
-    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), remote: true, class: 'tag-link' do
+    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), remote: true, class: 'tag-link nweet-tag-link' do
       span class="badge badge-tag mx-1 #{'active' if is_link_categorized = link.categories.exists?(name: category)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = category

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,7 +18,7 @@ html
     = favicon_link_tag('favicon.ico')
     link rel="manifest" href="/manifest.json"
     link rel="apple-touch-icon" href="#{asset_url('logomark_color.png')}"
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag  'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application'
     = javascript_pack_tag 'header'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,6 +29,7 @@ html
     = javascript_pack_tag 'notification'
     = javascript_pack_tag 'christmas'
     = javascript_pack_tag 'pagination'
+    = javascript_pack_tag 'categories'
     = analytics_init if Rails.env.production?
   body
     = render 'layouts/header'

--- a/app/views/nweets/_create_form.html.slim
+++ b/app/views/nweets/_create_form.html.slim
@@ -1,4 +1,4 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
   /= render 'shared/error_messages', object: f.object
   .field
-    = f.submit "#nuita!", class: "btn btn-nuita btn-block", id: "button-nuita"
+    = f.submit "#nuita!", class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_create_form.html.slim
+++ b/app/views/nweets/_create_form.html.slim
@@ -1,4 +1,3 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  /= render 'shared/error_messages', object: f.object
-  .field
+  .field.mx-2.mx-md-0
     = f.submit "#nuita!", class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -1,5 +1,5 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita", id: "button-nuita"
-  .statement-label やりましたね！今の気持ちを伝えてください。
-  = f.text_area :statement, maxlength: 100, rows: 2, class: "statement form-control"
-  = f.submit "情報を更新する！", class: "btn btn-block btn-nuita btn-edit"
+  = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
+  .statement-label コメント
+  = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control", placeholder: '感想・使用したオカズを入力'
+  = f.submit "情報を更新する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -7,7 +7,7 @@
     .col.form-check.form-check-inline
       - Category.pluck(:name).each do |category|
         = button_tag type: 'button', class: 'toggle-tag-link tag-link not-button' do
-          span class="badge badge-tag mx-1 #{'active' if 1 == 2}"
+          span class="badge badge-tag mx-1"
             span.small = icon 'fas', 'hashtag'
             span.pr-1 = category
             span.small.delete_icon = icon 'fas', 'plus'

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -6,7 +6,7 @@
   .row.mx-2.mx-md-0
     .col.form-check.form-check-inline
       - Category.pluck(:name).each do |category|
-        = link_to root_path, method: :get, remote: true, class: 'tag-link' do
+        = button_tag type: 'button', class: 'toggle-tag-link tag-link not-button' do
           span class="badge badge-tag mx-1 #{'active' if 1 == 2}"
             span.small = icon 'fas', 'hashtag'
             span.pr-1 = category

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -1,5 +1,18 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
-  .statement-label コメント
-  = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control", placeholder: '感想・使用したオカズを入力'
-  = f.submit "情報を更新する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"
+  .row.mx-2.mx-md-0
+    = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
+  .row.mx-2.mx-md-0
+    = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力'
+  .row.mx-2.mx-md-0
+    .col.form-check.form-check-inline
+      - Category.pluck(:name).each do |category|
+        = link_to root_path, method: :get, remote: true, class: 'tag-link' do
+          span class="badge badge-tag mx-1 #{'active' if 1 == 2}"
+            span.small = icon 'fas', 'hashtag'
+            span.pr-1 = category
+            span.small.delete_icon = icon 'fas', 'plus'
+          = hidden_field_tag "categories[#{category}]", 0
+    .col-auto.pr-0
+      = f.select :privacy, Nweet.privacies.map{ |k, v| [Nweet.human_attribute_name("privacy.#{k}"), v] }, {}, {class: "form-control form-control-sm nuita-selectbox mt-2"}
+  .row.mx-2.mx-md-0
+    = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/_home_form.html.slim
+++ b/app/views/nweets/_home_form.html.slim
@@ -1,0 +1,2 @@
+.field.mx-2.mx-md-0
+  = link_to "#nuita!", new_nweet_path, class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -1,0 +1,19 @@
+= form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
+  .row.mx-2.mx-md-0
+    = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
+  .row.mx-2.mx-md-0
+    = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力'
+  .row.mx-2.mx-md-0
+    .col.form-check.form-check-inline
+      - Category.pluck(:name).each do |category|
+        = button_tag type: 'button', class: 'toggle-tag-link tag-link not-button' do
+          span class="badge badge-tag mx-1"
+            span.small = icon 'fas', 'hashtag'
+            span.pr-1 = category
+            span.small.delete_icon = icon 'fas', 'plus'
+          = hidden_field_tag "categories[#{category}]", 0
+    .col-auto.pr-0
+      = f.select :privacy, Nweet.privacies.map{ |k, v| [Nweet.human_attribute_name("privacy.#{k}"), v] }, {}, {class: "form-control form-control-sm nuita-selectbox mt-2"}
+  = f.hidden_field :did_at, value: @nweet.did_at
+  .row.mx-2.mx-md-0
+    = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -13,7 +13,7 @@
             span.small.delete_icon = icon 'fas', 'plus'
           = hidden_field_tag "categories[#{category}]", 0
     .col-auto.pr-0
-      = f.select :privacy, Nweet.privacies.map{ |k, v| [Nweet.human_attribute_name("privacy.#{k}"), v] }, {}, {class: "form-control form-control-sm nuita-selectbox mt-2"}
+      = f.select :privacy, Nweet.privacies.map{ |k, v| [Nweet.human_attribute_name("privacy.#{k}"), k.to_s] }, {}, {class: "form-control form-control-sm nuita-selectbox mt-2"}
   = f.hidden_field :did_at, value: @nweet.did_at
   .row.mx-2.mx-md-0
     = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -19,10 +19,19 @@ li.nweet id="nweet#{nweet.url_digest}" class="cb-#{nweet.user.has_christmas_badg
           = link_to '', christmas_path, class: 'christmas-badge-icon'
         - else
           | 。
-      - if nweet.links.any?
-        = render 'cards/vertical', link: nweet.links.first
-      - if nweet.statement? && (!@timeline || followee_or_self?(nweet.user))
-        .quote = text_url_to_link(nweet.statement).html_safe
+        - unless nweet.to_everyone?
+          .ml-1.badge.badge-secondary = "#{Nweet.human_attribute_name("privacy.#{nweet.privacy.to_s}")}"
+      - if link_visible?(nweet)
+        - if nweet.links.any?
+          = render 'cards/vertical', link: nweet.links.first
+        - if nweet.statement? && (!@timeline || followee_or_self?(nweet.user))
+          .quote = text_url_to_link(nweet.statement).html_safe
+      - else
+        - if nweet.to_followers?
+          .p-1.text-small.alert.alert-secondary
+            | このユーザーを
+            = link_to 'フォロー', user_path(nweet.user)
+            | して詳細を確認しましょう
       .nweet-bottom
         .float-left
           - if user_signed_in?

--- a/app/views/nweets/new.html.slim
+++ b/app/views/nweets/new.html.slim
@@ -5,7 +5,7 @@
     .d-none.d-md-block.col-md-3
       = render 'users/user_info', {user: current_user}
     .col-md-6.p-0
-      = render 'nweets/home_form'
+      = render 'nweets/new_form'
       = render 'pages/timeline'
     .d-none.d-md-block.col-md-3
       = render 'pages/recommend'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,9 +24,9 @@ ja:
         privacy: "公開設定"
       nweet/privacy:
         to_everyone: "全員に公開"
-        to_followers: "フォロワーのみ"
-        to_friends: "相互フォローのみ"
-        to_author_only: "自分のみ"
+        to_followers: "フォロワー限定"
+        to_friends: "相互フォロー限定"
+        to_author_only: "非公開"
   date:
     abbr_day_names:
     - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     models:
       users: ユーザー
+      nweets: ヌイート
     attributes:
       user:
         handle_name: "ハンドルネーム"
@@ -19,6 +20,13 @@ ja:
         password_confirmation: "パスワード(確認)"
         icon: "アイコン"
         biography: "ひとこと"
+      nweet:
+        privacy: "公開設定"
+      nweet/privacy:
+        to_everyone: "全員に公開"
+        to_followers: "フォロワーのみ"
+        to_friends: "相互フォローのみ"
+        to_author_only: "自分のみ"
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :nweets, only: [:create, :update, :destroy, :show], param: :url_digest
+  resources :nweets, except: [:index], param: :url_digest
   resource :category, only: [:create, :destroy]
   resource :like, only: [:create, :destroy]
   resource :link, only: [:create]

--- a/db/migrate/20200120190601_add_privacy_to_nweets.rb
+++ b/db/migrate/20200120190601_add_privacy_to_nweets.rb
@@ -1,0 +1,5 @@
+class AddPrivacyToNweets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :nweets, :privacy, :integer
+  end
+end

--- a/db/migrate/20200120193252_set_defaults_in_privacy_in_nweets.rb
+++ b/db/migrate/20200120193252_set_defaults_in_privacy_in_nweets.rb
@@ -1,0 +1,11 @@
+class SetDefaultsInPrivacyInNweets < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :nweets, :privacy, false, 0
+    change_column :nweets, :privacy, :integer, default: 0
+  end
+
+  def down
+    change_column_null :nweets, :privacy, true, nil
+    change_column :nweets, :privacy, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_190601) do
+ActiveRecord::Schema.define(version: 2020_01_20_193252) do
 
   create_table "badges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_190601) do
     t.text "statement"
     t.string "url_digest"
     t.datetime "latest_liked_time"
-    t.integer "privacy"
+    t.integer "privacy", default: 0, null: false
     t.index ["url_digest"], name: "index_nweets_on_url_digest", unique: true
     t.index ["user_id", "did_at"], name: "index_nweets_on_user_id_and_did_at"
     t.index ["user_id"], name: "index_nweets_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_17_162634) do
+ActiveRecord::Schema.define(version: 2020_01_20_190601) do
 
   create_table "badges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2020_01_17_162634) do
     t.text "statement"
     t.string "url_digest"
     t.datetime "latest_liked_time"
+    t.integer "privacy"
     t.index ["url_digest"], name: "index_nweets_on_url_digest", unique: true
     t.index ["user_id", "did_at"], name: "index_nweets_on_user_id_and_did_at"
     t.index ["user_id"], name: "index_nweets_on_user_id"

--- a/test/controllers/nweets_controller_test.rb
+++ b/test/controllers/nweets_controller_test.rb
@@ -67,4 +67,14 @@ class NweetsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal '誰だ今の', @friend_nweet.statement
   end
 
+  test 'can set categories when create nweet' do
+    login_as(@user)
+
+    gro_url = 'https://dic.pixiv.net/a/R-18G'
+    post nweets_path, params: {nweet: {statement: gro_url, did_at: 1.minute.ago}, categories: {'R18G': '1', '3D': '0'} }
+    link = Link.find_by(url: gro_url)
+    assert link.categories.exists?(name: 'R18G')
+    assert_not link.categories.exists?(name: '3D')
+  end
+
 end


### PR DESCRIPTION
細かい仕様はまだ具体的に決まってないけど、facebookみたいに投稿時の画面で公開範囲を設定できるようにしたい。非公開にできるのはオカズとコメントだけで、射精した事実はTLに流す

「公開」「フォロワーのみ公開」「FFのみ公開」「自分だけ」の4つを用意してあるけど、最初は左2つだけ実装して様子を見てみたい

これでオカズ流したり射精報告したりすることへの心理的抵抗が薄まってくれれば……。