### PR TITLE
新しいヌイート投稿画面

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -389,26 +389,24 @@ body{
   border-radius: 0.3rem;
 }
 
-.badge-tag{
-  background-color: #fcfcfc;
-  border: 1px solid $brand-color;
-  color: $brand-color;
-  a{
-    color: inherit;
+a.tag-link{
+  .badge-tag{
+    background-color: #fcfcfc;
+    border: 1px solid $brand-color;
+    color: $brand-color;
     text-decoration: none;
   }
-}
 
-.badge-tag.active{
-  background-color: $brand-color;
-  color: #fff;
-  a{
-    color: inherit;
+  .badge-tag.active{
+    background-color: $brand-color;
+    color: #fff;
     text-decoration: none;
 
     .delete_icon{
       color: $brand-color-light;
-      &:hover{
+    }
+    &:hover{
+      .delete_icon{
         color: white;
       }
     }

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -204,8 +204,12 @@ body{
   }
 }
 
-  .wider-margintop{
-  margin-top: 30px;
+.wider-margintop{
+  margin-top: 30px !important;
+}
+
+.wider-marginbottom{
+  margin-bottom: 20px !important;
 }
 
 .btn.btn-unfollow{
@@ -652,8 +656,8 @@ body{
 
 .btn.btn-block.btn-nuita {
   font-size: larger;
-  margin: 30px auto;
-  padding: 10px 30px 10px 30px;
+  margin: 10px auto;
+  padding: 10px 30px;
   border-radius: 10px;
   text-decoration: none;
   background-color: $brand-color;/*ボタン色*/
@@ -692,8 +696,8 @@ body{
 }
 
 /* edit */
-.statement {
-  margin: 10px auto;
+.statement-textbox {
+  margin: 0.125rem auto;
 	border: 1px solid $brand-color-light;
 	border-radius: 10px;
 	width: 100%;
@@ -706,7 +710,7 @@ body{
 }
 
 .statement-label {
-
+  font-size: small;
 }
 
 .like-color{

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -382,7 +382,7 @@ body{
   border-radius: 0.3rem;
 }
 
-a.tag-link{
+.tag-link{
   .badge-tag{
     background-color: #fcfcfc;
     border: 1px solid $brand-color;
@@ -975,4 +975,14 @@ table.table-contribution.detailed-true{
 
 .x-small{
   font-size: x-small;
+}
+
+button{
+  background: transparent;
+  padding: 0;
+  border: none;
+}
+
+button:focus:not(.focus-visible) {
+  outline: none;
 }

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -139,13 +139,6 @@ $contribution-color-more: rgb(25, 97, 39);
   }
 }
 
-@media screen and (max-width: 768px){
-  .nuita-form{
-    width: 95%;
-    margin: 0 auto;
-  }
-}
-
 body{
   padding-top: 48px;
   font-family: "Questrial", sans-serif;
@@ -693,7 +686,7 @@ a.tag-link{
   margin: 30px auto;
 }
 
-/* edit */
+/* nweets#new */
 .statement-textbox {
   margin: 0.125rem auto;
 	border: 1px solid $brand-color-light;
@@ -709,6 +702,18 @@ a.tag-link{
 
 .statement-label {
   font-size: small;
+}
+
+.nuita-selectbox {
+  margin: auto;
+  border: 1px solid $brand-color-light;
+  border-radius: 10px;
+  resize: none;
+
+  &:focus {
+    border: 2px solid $brand-color-light;
+    outline: 0;
+  }
 }
 
 .like-color{

--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -697,6 +697,8 @@ body{
   &:focus {
     border: 2px solid $brand-color-light;
     outline: 0;
+    box-shadow: none;
+    padding: calc(0.375rem - 1px) calc(0.75rem - 1px);
   }
 }
 

--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -16,6 +16,9 @@ class NweetsController < ApplicationController
     @nweet = current_user.nweets.build(new_nweet_params)
     if @nweet.save
       flash[:success] = 'ヌイートを投稿しました！'
+      if @nweet.links.any?
+        set_categories(@nweet.links.first)
+      end
       tweet if current_user.autotweet_enabled
     else
       flash[:danger] = @nweet.errors.full_messages
@@ -36,6 +39,7 @@ class NweetsController < ApplicationController
     redirect_to root_url
   end
 
+  # obsolete
   def update
     @nweet = Nweet.find_by(url_digest: params[:url_digest])
 
@@ -61,5 +65,12 @@ class NweetsController < ApplicationController
     def correct_user
       @nweet = current_user.nweets.find_by(url_digest: params[:url_digest])
       redirect_to root_url if @nweet.nil?
+    end
+
+    def set_categories(link)
+      # 正直カテゴリーの中身mass assignmentされても何の脆弱性もないたぶん
+      params.permit(categories: {}).to_hash["categories"].each do |category_name, value|
+        link.set_category(category_name) if value == '1'
+      end
     end
 end

--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -1,16 +1,27 @@
 class NweetsController < ApplicationController
-  before_action :authenticate_user!, only: [:create, :destroy]
-  before_action :correct_user, only: [:destroy, :update]
+  before_action :authenticate_user!, except: [:show]
+  before_action :correct_user, only: [:update, :destroy]
+
+  def new
+    @nweet = current_user.nweets.build(did_at: Time.zone.now)
+    @feed_items = current_user.timeline.paginate(page: params[:page])
+    @timeline = true
+
+    if params[:scroll]
+      render partial: 'nweets/nweet', collection: @feed_items
+    end
+  end
 
   def create
-    @nweet = current_user.nweets.build(did_at: Time.zone.now)
-    if @nweet.save # edit に移すべきかも
-      redirect_to root_url(success: true, url_digest: @nweet.url_digest)
+    @nweet = current_user.nweets.build(new_nweet_params)
+    if @nweet.save
+      flash[:success] = 'ヌイートを投稿しました！'
       tweet if current_user.autotweet_enabled
     else
       flash[:danger] = @nweet.errors.full_messages
-      redirect_to root_url(success: false)
     end
+
+    redirect_to root_url
   end
 
   def show
@@ -39,6 +50,10 @@ class NweetsController < ApplicationController
 
   private
     # strong parameters
+    def new_nweet_params
+      params.require(:nweet).permit(:statement, :did_at)
+    end
+
     def edit_nweet_params
       params.require(:nweet).permit(:statement)
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,7 @@
 class PagesController < ApplicationController
   def home
     if user_signed_in?
-      if params[:success] == 'true'
-        @nweet = Nweet.find_by(url_digest: params[:url_digest])
-      else
-        @nweet = current_user.nweets.build
-      end
+      @nweet = current_user.nweets.build
       @feed_items = current_user.timeline.paginate(page: params[:page])
       @timeline = true
 

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -9,4 +9,20 @@ module CategoriesHelper
       link.categories.where(censored_by_default: true).pluck(:name)
     end
   end
+
+  def category_method(is_existing)
+    if is_existing
+      :delete
+    else
+      :post
+    end
+  end
+
+  def category_icon(is_existing)
+    if is_existing
+      "times"
+    else
+      "plus"
+    end
+  end
 end

--- a/app/javascript/packs/categories.ts
+++ b/app/javascript/packs/categories.ts
@@ -1,0 +1,22 @@
+let setIndividualCategoryButton = (event:Event) => {
+  let a = <HTMLElement>event.currentTarget;
+
+  let badge = <HTMLElement>a.firstChild;
+  let i = <HTMLElement>badge.childNodes[2].firstChild;
+
+  if(a.getAttribute('data-method') == 'post'){
+    a.setAttribute('data-method', 'delete');
+    i.classList.replace('fa-plus', 'fa-times');
+    badge.classList.add('active');
+  }else{
+    a.setAttribute('data-method', 'post');
+    i.classList.replace('fa-times', 'fa-plus');
+    badge.classList.remove('active');
+  }
+}
+
+export function setCategoryButtons(){
+  document.querySelectorAll('.tag-link').forEach(function(div){
+    div.addEventListener('ajax:success', setIndividualCategoryButton);
+  });
+};

--- a/app/javascript/packs/categories.ts
+++ b/app/javascript/packs/categories.ts
@@ -1,3 +1,4 @@
+// 既に投稿されたオカズにタグつけるやつ (category#createとかに送る)
 let setIndividualCategoryButton = (event:Event) => {
   let a = <HTMLElement>event.currentTarget;
 
@@ -15,8 +16,33 @@ let setIndividualCategoryButton = (event:Event) => {
   }
 }
 
+// 新しく投稿するときにタグつけるやつ (JSでhidden_fieldの値変える)
+let setIndividualToggleTagButton = (event: Event) => {
+  let a = <HTMLElement>event.currentTarget;
+  let field = <HTMLElement>a.lastChild;
+
+  let n = parseInt(field.getAttribute('value'));
+  field.setAttribute('value', (1 - n).toString());
+  console.log(1 - n);
+
+  let badge = <HTMLElement>a.firstChild;
+  let i = <HTMLElement>badge.childNodes[2].firstChild;
+
+  if(i.classList.contains('fa-plus')){
+    i.classList.replace('fa-plus', 'fa-times');
+  }else{
+    i.classList.replace('fa-times', 'fa-plus');
+  }
+
+  badge.classList.toggle('active');
+};
+
 export function setCategoryButtons(){
-  document.querySelectorAll('.tag-link').forEach(function(div){
+  document.querySelectorAll('.nweet-tag-link').forEach(function(div){
     div.addEventListener('ajax:success', setIndividualCategoryButton);
+  });
+
+  document.querySelectorAll('.toggle-tag-link').forEach(function(div){
+    div.addEventListener('click', setIndividualToggleTagButton);
   });
 };

--- a/app/javascript/packs/categories.ts
+++ b/app/javascript/packs/categories.ts
@@ -1,5 +1,5 @@
 // 既に投稿されたオカズにタグつけるやつ (category#createとかに送る)
-let setIndividualCategoryButton = (event:Event) => {
+export let setIndividualCategoryButton = (event:Event) => {
   let a = <HTMLElement>event.currentTarget;
 
   let badge = <HTMLElement>a.firstChild;

--- a/app/javascript/packs/pagination.ts
+++ b/app/javascript/packs/pagination.ts
@@ -1,5 +1,6 @@
 import {setFollowIcons} from './follow_icon';
 import {setLikeButtons} from './nweets';
+import {setCategoryButtons} from './categories';
 
 document.addEventListener('turbolinks:load', function(){
   let paginateContainer = document.getElementById('willPaginateContainer');
@@ -51,6 +52,7 @@ document.addEventListener('turbolinks:load', function(){
       }
       setFollowIcons();
       setLikeButtons();
+      setCategoryButtons();
 
       isLoading = false;
     }, observerOptions);
@@ -58,6 +60,7 @@ document.addEventListener('turbolinks:load', function(){
     observer.observe(document.querySelector('#willPaginateContainer'));
   }else{
     setFollowIcons();
-    setLikeButtons();    
+    setLikeButtons();
+    setCategoryButtons();
   }
 });

--- a/app/javascript/packs/recommend.ts
+++ b/app/javascript/packs/recommend.ts
@@ -1,3 +1,11 @@
+import {setIndividualCategoryButton} from './categories'
+
+let setRecommendCategoryButton = () => {
+  document.querySelectorAll('#recommendCard .nweet-tag-link').forEach(function(div){
+    div.addEventListener('ajax:success', setIndividualCategoryButton);
+  });
+}
+
 document.addEventListener('turbolinks:load', () => {
   let recommendButton = document.getElementById("buttonRenewRecommend");
   if(recommendButton){
@@ -10,6 +18,7 @@ document.addEventListener('turbolinks:load', () => {
         let card = document.getElementById("recommendCard");
         card.textContent = "";
         card.insertAdjacentHTML("afterbegin", partial);
+        setRecommendCategoryButton();
       });
     });
   }

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -21,8 +21,7 @@ class Link < ApplicationRecord
   end
 
   def set_category(name)
-    name.upcase!
-    if c = Category.find_by(name: name)
+    if c = Category.find_by(name: name.upcase)
       self.categories << c
     end
   end

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,14 +1,8 @@
 .mt-0.mb-2
   - Category.pluck(:name).each do |category|
-    - if link.categories.exists?(name: category)
-      span.badge.badge-tag.active.mx-1
+    - is_link_categorized = link.categories.exists?(name: category)
+    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), class: 'tag-link' do
+      span class="badge badge-tag mx-1 #{'active' if is_link_categorized = link.categories.exists?(name: category)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = category
-        = link_to category_path(link_id: link.id, category_name: category), method: :delete do
-          span.small.delete_icon = icon 'fas', 'times'
-    - else
-      span.badge.badge-tag.mx-1
-        span.small = icon 'fas', 'hashtag'
-        span.pr-1 = category
-        = link_to category_path(link_id: link.id, category_name: category), method: :post do
-          span.small.delete_icon = icon 'fas', 'plus'
+        span.small.delete_icon = icon 'fas', category_icon(is_link_categorized)

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,7 +1,7 @@
 .mt-0.mb-2
   - Category.pluck(:name).each do |category|
     - is_link_categorized = link.categories.exists?(name: category)
-    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), class: 'tag-link' do
+    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), remote: true, class: 'tag-link' do
       span class="badge badge-tag mx-1 #{'active' if is_link_categorized = link.categories.exists?(name: category)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = category

--- a/app/views/cards/_categories.html.slim
+++ b/app/views/cards/_categories.html.slim
@@ -1,7 +1,7 @@
 .mt-0.mb-2
   - Category.pluck(:name).each do |category|
     - is_link_categorized = link.categories.exists?(name: category)
-    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), remote: true, class: 'tag-link' do
+    = link_to category_path(link_id: link.id, category_name: category), method: category_method(is_link_categorized), remote: true, class: 'tag-link nweet-tag-link' do
       span class="badge badge-tag mx-1 #{'active' if is_link_categorized = link.categories.exists?(name: category)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = category

--- a/app/views/cards/_collapse_button.html.slim
+++ b/app/views/cards/_collapse_button.html.slim
@@ -1,0 +1,8 @@
+div id="collapseButton#{link.id}"
+  - if tags.any?
+    .small.pb-1
+      span.pr-1 = icon('fas', 'exclamation-triangle')
+      - tags.each do |tag|
+        span.font-weight-bold.pr-1 = tag
+      span.collapse-button
+        a href= "#collapse#{type}#{link.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseHorizontal#{link.id}" 展開

--- a/app/views/cards/_horizontal.html.slim
+++ b/app/views/cards/_horizontal.html.slim
@@ -1,11 +1,5 @@
 - tags = censored_tags(link)
-- if tags.any?
-  .small.pb-1
-    span.pr-1 = icon('fas', 'exclamation-triangle')
-    - tags.each do |tag|
-      span.font-weight-bold.pr-1 = tag
-    span.collapse-button
-      a href= "#collapseHorizontal#{link.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseHorizontal#{link.id}" 展開
+= render 'cards/collapse_button', type: "Horizontal", link: link, tags: tags
 
 div id="collapseHorizontal#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do

--- a/app/views/cards/_vertical.html.slim
+++ b/app/views/cards/_vertical.html.slim
@@ -1,11 +1,5 @@
 - tags = censored_tags(link)
-- if tags.any?
-  .small.pb-1
-    span.pr-1 = icon('fas', 'exclamation-triangle')
-    - tags.each do |tag|
-      span.font-weight-bold.pr-1 = tag
-    span.collapse-button
-      a href= "#collapseVertical#{link.id}" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="collapseVertical#{link.id}" 展開
+= render 'cards/collapse_button', type: "Vertical", link: link, tags: tags
 
 div id="collapseVertical#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -29,6 +29,7 @@ html
     = javascript_pack_tag 'notification'
     = javascript_pack_tag 'christmas'
     = javascript_pack_tag 'pagination'
+    = javascript_pack_tag 'categories'
     = analytics_init if Rails.env.production?
   body
     = render 'layouts/header'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,7 +18,7 @@ html
     = favicon_link_tag('favicon.ico')
     link rel="manifest" href="/manifest.json"
     link rel="apple-touch-icon" href="#{asset_url('logomark_color.png')}"
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application'
     = javascript_pack_tag 'header'

--- a/app/views/nweets/_create_form.html.slim
+++ b/app/views/nweets/_create_form.html.slim
@@ -1,4 +1,4 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
   /= render 'shared/error_messages', object: f.object
   .field
-    = f.submit "#nuita!", class: "btn btn-nuita btn-block", id: "button-nuita"
+    = f.submit "#nuita!", class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_create_form.html.slim
+++ b/app/views/nweets/_create_form.html.slim
@@ -1,3 +1,0 @@
-= form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  .field.mx-2.mx-md-0
-    = f.submit "#nuita!", class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_create_form.html.slim
+++ b/app/views/nweets/_create_form.html.slim
@@ -1,4 +1,3 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  /= render 'shared/error_messages', object: f.object
-  .field
+  .field.mx-2.mx-md-0
     = f.submit "#nuita!", class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -1,5 +1,5 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita", id: "button-nuita"
-  .statement-label やりましたね！今の気持ちを伝えてください。
-  = f.text_area :statement, maxlength: 100, rows: 2, class: "statement form-control"
-  = f.submit "情報を更新する！", class: "btn btn-block btn-nuita btn-edit"
+  = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
+  .statement-label コメント
+  = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control", placeholder: '感想・使用したオカズを入力'
+  = f.submit "情報を更新する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -7,7 +7,7 @@
     .col.form-check.form-check-inline
       - Category.pluck(:name).each do |category|
         = button_tag type: 'button', class: 'toggle-tag-link tag-link not-button' do
-          span class="badge badge-tag mx-1 #{'active' if 1 == 2}"
+          span class="badge badge-tag mx-1"
             span.small = icon 'fas', 'hashtag'
             span.pr-1 = category
             span.small.delete_icon = icon 'fas', 'plus'

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -6,7 +6,7 @@
   .row.mx-2.mx-md-0
     .col.form-check.form-check-inline
       - Category.pluck(:name).each do |category|
-        = link_to root_path, method: :get, remote: true, class: 'tag-link' do
+        = button_tag type: 'button', class: 'toggle-tag-link tag-link not-button' do
           span class="badge badge-tag mx-1 #{'active' if 1 == 2}"
             span.small = icon 'fas', 'hashtag'
             span.pr-1 = category

--- a/app/views/nweets/_edit_form.html.slim
+++ b/app/views/nweets/_edit_form.html.slim
@@ -1,5 +1,16 @@
 = form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
-  = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
-  .statement-label コメント
-  = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control", placeholder: '感想・使用したオカズを入力'
-  = f.submit "情報を更新する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"
+  .row.mx-2.mx-md-0
+    = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
+  .row.mx-2.mx-md-0
+    = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力'
+  .row.mx-2.mx-md-0
+    .col.form-check.form-check-inline
+      - Category.pluck(:name).each do |category|
+        = link_to root_path, method: :get, remote: true, class: 'tag-link' do
+          span class="badge badge-tag mx-1 #{'active' if 1 == 2}"
+            span.small = icon 'fas', 'hashtag'
+            span.pr-1 = category
+            span.small.delete_icon = icon 'fas', 'plus'
+          = hidden_field_tag "categories[#{category}]", 0
+  .row.mx-2.mx-md-0
+    = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/_home_form.html.slim
+++ b/app/views/nweets/_home_form.html.slim
@@ -1,0 +1,2 @@
+.field.mx-2.mx-md-0
+  = link_to "#nuita!", new_nweet_path, class: "btn btn-nuita btn-block wider-margintop wider-marginbottom", id: "button-nuita"

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -12,5 +12,6 @@
             span.pr-1 = category
             span.small.delete_icon = icon 'fas', 'plus'
           = hidden_field_tag "categories[#{category}]", 0
+  = f.hidden_field :did_at, value: @nweet.did_at
   .row.mx-2.mx-md-0
     = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/app/views/nweets/new.html.slim
+++ b/app/views/nweets/new.html.slim
@@ -1,11 +1,11 @@
-- provide(:title, 'ホーム')
+- provide(:title, 'ヌイートを作成')
 
 .container-fluid
   .row
     .d-none.d-md-block.col-md-3
       = render 'users/user_info', {user: current_user}
     .col-md-6.p-0
-      = render 'nweets/home_form'
+      = render 'nweets/new_form'
       = render 'pages/timeline'
     .d-none.d-md-block.col-md-3
       = render 'pages/recommend'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :nweets, only: [:create, :update, :destroy, :show], param: :url_digest
+  resources :nweets, except: [:index], param: :url_digest
   resource :category, only: [:create, :destroy]
   resource :like, only: [:create, :destroy]
   resource :link, only: [:create]

--- a/test/controllers/nweets_controller_test.rb
+++ b/test/controllers/nweets_controller_test.rb
@@ -67,4 +67,13 @@ class NweetsControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal '誰だ今の', @friend_nweet.statement
   end
 
+  test 'can set categories when create nweet' do
+    login_as(@user)
+
+    gro_url = 'https://dic.pixiv.net/a/R-18G'
+    post nweets_path, params: {nweet: {statement: gro_url, did_at: 1.minute.ago}, categories: {'R18G': '1', '3D': '0'} }
+    link = Link.find_by(url: gro_url)
+    assert link.categories.exists?(name: 'R18G')
+    assert_not link.categories.exists?(name: '3D')
+  end
 end


### PR DESCRIPTION
すっきり〜

<img width="710" alt="スクリーンショット 2020-01-26 15 58 21" src="https://user-images.githubusercontent.com/19870474/73131791-b36e4400-4054-11ea-88d8-7c30af164b5c.png">

## ヌイートが投稿されるタイミングを変更
- これまでは **"#nuita!"ボタンが押されたタイミング** で一旦無言投稿(`nweets#create`)→`/?success=true`でオカズとか付け足してた(`nweets#edit`)
- 今後は"#nuita!"ボタンを押しただけでは投稿されない： **コメントの投稿が終わったタイミング** でコメントつきで投稿される
- ボタンは単に`/nweet/new`(`nweets#new`)へのリンクに, `nweets#new`のフォームが `nweets#create` を呼ぶ

- ツイートするタイミングもズレる→コメントの中身がtwitterカードに反映できるようになる
- 共有ボタンからヌイートとかをサポートする上でもこっちのほうがやりやすそう

## フォームの見た目を書き直した
- 「感想を入力」って何？？？？？いまのオカズ投稿する文化に合わせる
- オカズのカテゴリーが投稿時に設定できるようになった

- 将来的にプレビュー機能も実装したい

## タグの付け外しがajaxでできるようになった
- 上のカテゴリー付きのフォーム作るときの副産物
- BootstrapのCSSのおかげで、わりとかっこいい感じの遷移のしかたする
- ほかのいいねボタンとかもtransitionのアニメーションつけたほうがかっこよくなるかも