### PR TITLE
フォームの投稿後に画面遷移しない問題を修正

### DIFF
--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,6 +1,6 @@
 h2
   | Resend confirmation instructions
-= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+= form_with model: resource, as: resource_name, url: confirmation_path(resource_name), local: true, method: :post do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
     = f.label :email

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -1,6 +1,6 @@
 h2
   | Change your password
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+= form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put, local: true) do |f|
   = render "devise/shared/error_messages", resource: resource
   = f.hidden_field :reset_password_token
   .field

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,6 +1,6 @@
 h2
   | Forgot your password?
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+= form_with(model: resource, as: resource_name, url: password_path(resource_name), method: :put, local: true) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
     = f.label :email

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -3,7 +3,7 @@
 .container.wider-margintop
   .jumbotron.not-so-jumbo.mx-auto
     h1 プロフィールを編集する
-    = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "form-group" }) do |f|
+    = form_with(model: resource, as: resource_name, url: registration_path(resource_name), method: :put, local: true, class: "form-group") do |f|
       = render "devise/shared/error_messages", resource: resource
       .form-group.row.align-items-center
         .col-md-3

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -89,7 +89,7 @@
       p = link_to "twitterアカウントを登録", "/auth/twitter", class: "btn btn-twitter", method: :post
     h3.pt-4 その他のオプション
     h5 検閲カテゴリ
-    = form_with url: censoring_path(current_user), method: :put, class: "form-group" do |f|
+    = form_with url: censoring_path(current_user), method: :put, class: "form-group", local: true do |f|
       .form-group
         - Category.pluck(:name).each do |category_name|
           .form-check.form-check-inline

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -3,7 +3,7 @@
 .container.wider-margintop
   .jumbotron.not-so-jumbo.mx-auto
     h1.mb-4 Nuitaに登録する
-    = form_for(resource, as: resource_name, html: {class: "form-group"}, url: registration_path(resource_name)) do |f|
+    = form_with(model: resource, as: resource_name, local: true, class: "form-group", url: registration_path(resource_name)) do |f|
       = render "devise/shared/error_messages", resource: resource
       .form-group.row.align-items-center
         .col-md-3

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -3,7 +3,7 @@
 .container.wider-margintop
   .jumbotron.not-so-jumbo.mx-auto
     h1.mb-4 ログイン
-    = form_for(resource, html: {class: 'form-group'}, as: resource_name, url: session_path(resource_name)) do |f|
+    = form_with(model: resource, class: 'form-group', as: resource_name, local: true, url: session_path(resource_name)) do |f|
       = render "devise/shared/error_messages", resource: resource
       .form-group.row
         .col-md-3

--- a/app/views/devise/unlocks/new.html.slim
+++ b/app/views/devise/unlocks/new.html.slim
@@ -1,6 +1,6 @@
 h2
   | Resend unlock instructions
-= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+= form_with(model: resource, as: resource_name, url: unlock_path(resource_name), local: true,method: :post) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
     = f.label :email

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -1,4 +1,4 @@
-= form_with(model: @nweet, html: {class: 'nuita-form'}) do |f|
+= form_with(model: @nweet, html: {class: 'nuita-form'}, local: true) do |f|
   .row.mx-2.mx-md-0
     = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
   .row.mx-2.mx-md-0


### PR DESCRIPTION
form_withだと画面遷移させるために`local: true`って指定しなきゃいけなかった