### PR TITLE
PWAのシェアメニューに対応させる

### DIFF
--- a/app/assets/javascripts/manifest.json.erb
+++ b/app/assets/javascripts/manifest.json.erb
@@ -18,12 +18,10 @@
   "display": "standalone",
   "orientation": "portrait",
   "share_target": {
-    "action": "/",
+    "action": "/nweets/new",
     "method": "GET",
     "params": {
-      "title": "title",
-      "text": "text",
-      "url": "url"
+      "url": "text"
     }
   }
 }

--- a/app/assets/javascripts/manifest.json.erb
+++ b/app/assets/javascripts/manifest.json.erb
@@ -16,5 +16,14 @@
   "theme_color": "#5FC10C",
   "background_color": "#5FC10C",
   "display": "standalone",
-  "orientation": "portrait"
+  "orientation": "portrait",
+  "share_target": {
+    "action": "/",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
 }

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -2,7 +2,7 @@
   .row.mx-2.mx-md-0
     = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop", id: "button-nuita"
   .row.mx-2.mx-md-0
-    = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力'
+    = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力', value: params[:text]
   .row.mx-2.mx-md-0
     .col.form-check.form-check-inline
       - Category.pluck(:name).each do |category|


### PR DESCRIPTION
`/nweets/new?text=` でテキストを埋められるようにして、そこにPWAの共有機能で閲覧しているウェブサイトのURLを渡せるようにしました。

動作確認してないので、なんか環境あったら試してもらうと良さそう。