### PR TITLE
[PWA]Chromeはurlは空でtextにページのURLが入る

### DIFF
--- a/app/assets/javascripts/manifest.json.erb
+++ b/app/assets/javascripts/manifest.json.erb
@@ -20,8 +20,9 @@
   "share_target": {
     "action": "/nweets/new",
     "method": "GET",
+    "enctype": "application/x-www-form-urlencoded",
     "params": {
-      "url": "text"
+      "text": "text"
     }
   }
 }


### PR DESCRIPTION
fix: https://github.com/nuita/nuita/issues/127

https://github.com/nuita/nuita/pull/126 で足したんですが、ちょっと動作確認出来てなかったところ動いてなかった。

今回は気合い入れて手元に開発環境立てて、portfowardして手元のAndroid Chromeで様子を見たので大丈夫そう。