### PR TITLE
ランディングページのランダムえっちに表示されるオカズを制限

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -4,6 +4,7 @@ require 'nokogiri'
 class LinksController < ApplicationController
   def recommend
     category_editable = true if user_signed_in?
-    render partial: 'cards/horizontal', locals: {link: Link.recommend, genre_hidden?: !category_editable}
+    
+    render partial: 'cards/horizontal', locals: {link: Link.recommend(displayable: params[:displayable]), genre_hidden?: !category_editable}
   end
 end

--- a/app/frontend/src/recommend.ts
+++ b/app/frontend/src/recommend.ts
@@ -1,16 +1,16 @@
-export default function setRecommendButton(){
+export default function setRecommendButton() {
   let recommendButton = document.getElementById("buttonRenewRecommend");
-  if(recommendButton){
+  if (recommendButton) {
     recommendButton.addEventListener("click", () => {
-      fetch('/links/recommend')
-      .then((response) => {
-        return response.text();
-      })
-      .then((partial:string) => {
-        let card = document.getElementById("recommendCard");
-        card.textContent = "";
-        card.insertAdjacentHTML("afterbegin", partial);
-      });
+      fetch('/links/recommend') // landingでも更新ボタン押すとR18Gとか出てくるけどまあいいでしょ・・・
+        .then((response) => {
+          return response.text();
+        })
+        .then((partial: string) => {
+          let card = document.getElementById("recommendCard");
+          card.textContent = "";
+          card.insertAdjacentHTML("afterbegin", partial);
+        });
     });
   }
 }

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -10,6 +10,8 @@ class Link < ApplicationRecord
 
   validates :url, :url => true
 
+  scope :displayable, -> { where.not(image: [nil, '']).left_outer_joins(:categories).where(categories: {censored_by_default: nil}) }
+
   def refetch
     fetch_infos
     save
@@ -27,8 +29,14 @@ class Link < ApplicationRecord
   end
 
   class << self
-    def recommend
-      Link.offset(rand(Link.count)).first
+    def recommend(displayable: false)
+      if(displayable)
+        link = Link.displayable  
+      else
+        link = Link.all
+      end
+      
+      link.offset(rand(link.count)).first
     end
 
     # URLを正規化してfind_or_initialize_by + fetchしてくる

--- a/app/views/pages/_recommend.html.slim
+++ b/app/views/pages/_recommend.html.slim
@@ -6,4 +6,5 @@ section.side-section
     button.btn.btn-sm.btn-outline-secondary.btn-brandcolor-hover.py-0.px-1 data-toggle="tooltip" data-placement="top" title="全ユーザーのヌイートからランダムで1つオカズが選ばれます。射精した本人と紐づくことはありません。"
       = icon 'fas', 'question'
   - if Link.any?
-    #recommendCard = render 'cards/horizontal', link: Link.recommend, genre_hidden?: local_assigns[:landing?]
+    - displayable = local_assigns[:landing?] # ユーザーがラジカル検閲要求するようになったらこのコードは変える
+    #recommendCard = render 'cards/horizontal', link: Link.recommend(displayable: displayable), genre_hidden?: local_assigns[:landing?]


### PR DESCRIPTION
ランディングページでは
- 画像なしのオカズ
- カテゴリ(R18G,3D...)つきのオカズ

が最初から表示されなくなる。
ただし、自分から更新ボタンを押した場合には通常通り全てのオカズから表示される。