### PR TITLE
Camoを本番環境でしか使わないようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'faker'
 gem "nokogiri", ">= 1.10.4"
 gem 'valid_url'
 gem 'fastimage'
-gem 'camo'
 
 gem 'mysql2'
 
@@ -88,6 +87,7 @@ end
 group :production, :staging do
   gem 'unicorn'
   gem 'google-analytics-rails'
+  gem 'camo'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,4 +25,12 @@ module ApplicationHelper
     end
   end
 
+  # returns camo url only in production mode
+  def camo_url(url)
+    if Rails.env.production?
+      camo(url)
+    else
+      url
+    end
+  end
 end

--- a/app/views/cards/_horizontal.html.slim
+++ b/app/views/cards/_horizontal.html.slim
@@ -4,7 +4,7 @@
 div id="collapseHorizontal#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do
     - if link.image?
-      img.card-img-top.h-100 loading='lazy' src = camo(link.image) height = link&.image_height width = link&.image_width
+      img.card-img-top.h-100 loading='lazy' src = camo_url(link.image) height = link&.image_height width = link&.image_width
     .card-body
       h5.card-title = link.title
       p.card-text = link.description

--- a/app/views/cards/_vertical.html.slim
+++ b/app/views/cards/_vertical.html.slim
@@ -6,7 +6,7 @@ div id="collapseVertical#{link.id}" class="#{'collapse' if tags.any?}"
     .row.no-gutters.align-items-center
       - if link.image?
         .col-md-6.p-0
-          img.card-img.h-100 loading='lazy' src = camo(link.image) width=link&.image_width height = link&.image_height
+          img.card-img.h-100 loading='lazy' src = camo_url(link.image) width=link&.image_width height = link&.image_height
       .col.p-0
         .card-body
           h5.card-title = link.title

--- a/config/initializers/camo.rb
+++ b/config/initializers/camo.rb
@@ -1,2 +1,4 @@
-ENV["CAMO_HOST"] = Rails.application.credentials.camo[:host]
-ENV["CAMO_KEY"] = Rails.application.credentials.camo[:key]
+if Rails.env.production?
+  ENV["CAMO_HOST"] = Rails.application.credentials.camo[:host]
+  ENV["CAMO_KEY"] = Rails.application.credentials.camo[:key]
+end


### PR DESCRIPTION
#144 の続き

ヘルパー `camo_url` を使うと環境に応じていい感じにurl振り分けてくれるよ