### PR TITLE
camo使う範囲をhttp通信に限定

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
 
   # returns camo url only in production mode
   def camo_url(url)
-    if Rails.env.production?
+    if Rails.env.production? && /http:\/\// =~ url
       camo(url)
     else
       url


### PR DESCRIPTION
負荷軽減＆安定のため