### PR TITLE
ヌイート内のカードを縦から横に変更

### DIFF
--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -16,7 +16,7 @@ li.nweet id="nweet#{nweet.url_digest}"
         span.time = time_ago_in_japanese(nweet.did_at)
         | に射精しました。
       - if nweet.links.any?
-        = render 'cards/vertical', link: nweet.links.first
+        = render 'cards/horizontal', link: nweet.links.first
       - if nweet.statement? && (!@timeline || followee_or_self?(nweet.user))
         .quote = text_url_to_link(nweet.statement).html_safe
       .nweet-bottom


### PR DESCRIPTION
こっちのほうが画像大きくなって必要スクロール数増えるから、場合によってはtwitterとかPixivみたいに一部を切り出したほうがいいかも