### PR TITLE
オカズの取得に失敗してもヌイート自体は投稿できるようにする

### DIFF
--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -45,7 +45,11 @@ class Nweet < ApplicationRecord
   def create_link
     if self.statement
       URI.extract(self.statement, ['http', 'https']).uniq.each do |url|
-        self.links << Link.fetch_from(url)
+        begin
+          self.links << l if l = Link.fetch_from(url)
+        rescue
+          logger.debug "Creating Link for #{url} has failed."
+        end
       end
     end
   end

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -124,13 +124,6 @@ class LinkTest < ActiveSupport::TestCase
     assert_equal 'https://t.komiflo.com/564_mobile_large_3x/contents/cdcfb81ea67a74519b8ad9dea6de8c5d4cec9f9f.jpg', @link.image
   end
 
-  test 'deal correctly with incorrect url' do
-    url = 'http://not-val.id/'
-    @link = Link.fetch_from(url)
-
-    assert_equal @link.url, @link.title
-  end
-
   test 'link can have category' do
     link = Link.fetch_from('https://www.pixiv.net/member_illust.php?mode=medium&illust_id=76477824')
     assert link.valid?

--- a/test/models/nweet_test.rb
+++ b/test/models/nweet_test.rb
@@ -83,6 +83,12 @@ class NweetTest < ActiveSupport::TestCase
     assert_equal link, nweet_again.links.first
   end
 
+  test 'nweet must be created even if url is not valid' do
+    assert_difference 'Nweet.count', 1 do
+      @user.nweets.create(did_at: 1.minutes.ago, statement: "I like this vid! http://not-val.id/")
+    end
+  end
+
   test 'tags in nweet must NOT be generated as category' do
     str = "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=75609372 #pixiv"
     nweet = @user.nweets.create(did_at: Time.zone.now, statement: str)


### PR DESCRIPTION
- fetch自体には成功しても、active_recordに書き込むタイミングでミスることがある（特殊文字とか）

- ヌイート側にも例外処理のところ作ってオカズの取得に失敗してもヌイート自体は投稿できるようにした