### PR TITLE
Link.refetch()をリライト

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 require File.expand_path("./environment", __dir__)
 
 # capistranoのバージョン固定
-lock "3.11.1"
+lock "3.13.0"
 
 # デプロイするアプリケーション名
 set :application, 'nuita'


### PR DESCRIPTION
Link.refetch(), link_task::refetch_all がfetch_from使う形式に適用できてなかったので書き換えた

refetch()は今後rakeタスクから以外は使わないようにする