### PR TITLE
link_task:refetch_*** の実行時のエラーをわかりやすくする

### DIFF
--- a/lib/tasks/link_task.rake
+++ b/lib/tasks/link_task.rake
@@ -2,16 +2,42 @@ namespace :link_task do
   desc "refetch all melonbook items"
   task refetch_melonbooks: :environment do
     Link.where("url LIKE '%melonbooks%'").find_each do |link|
-      link.refetch
-      p link
+      begin
+        link.refetch
+        print "#{link.id} "
+      rescue => e
+        puts "\n#{e}"
+        p link
+      ensure
+      end
     end
   end
 
   desc "refetch all pixiv items"
   task refetch_pixiv: :environment do
     Link.where("url LIKE '%pixiv%'").find_each do |link|
-      link.refetch
-      p link
+      begin
+        link.refetch
+        print "#{link.id} "
+      rescue => e
+        puts "\n#{e}"
+        p link
+      ensure
+      end
+    end
+  end
+
+  desc "refetch all dlsite items"
+  task refetch_dlsite: :environment do
+    Link.where("url LIKE '%dlsite%'").find_each do |link|
+      begin
+        link.refetch
+        print "#{link.id} "
+      rescue => e
+        puts "\n#{e}"
+        p link
+      ensure
+      end
     end
   end
 
@@ -20,10 +46,11 @@ namespace :link_task do
     Link.all.find_each do |link|
       begin
         link.refetch
+        print "#{link.id} "
       rescue => e
-        puts e
-      ensure
+        puts "\n#{e}"
         p link
+      ensure
       end
     end
   end


### PR DESCRIPTION
- `p link` で全レコード表示するのをやめて数字だけにした（エラーを目立たせるため）
- 個別サイトへの `refetch_***` も例外処理いれて最後まで回すようにした