### PR TITLE
無限スクロール用の読み込み処理を改善

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,11 +2,14 @@ class PagesController < ApplicationController
   def home
     if user_signed_in?
       @nweet = current_user.nweets.build
-      @feed_items = current_user.timeline.limit(10)
       @timeline = true
 
-      if params[:scroll]
+      if params[:before]
+        @before = Nweet.find_by(url_digest: params[:before])
+        @feed_items = current_user.timeline.where('did_at < ?', @before.did_at).limit(10)
         render partial: 'nweets/nweet', collection: @feed_items
+      else
+        @feed_items = current_user.timeline.limit(10)
       end
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@ class PagesController < ApplicationController
   def home
     if user_signed_in?
       @nweet = current_user.nweets.build
-      @feed_items = current_user.timeline.paginate(page: params[:page])
+      @feed_items = current_user.timeline.limit(10)
       @timeline = true
 
       if params[:scroll]

--- a/app/frontend/packs/application.ts
+++ b/app/frontend/packs/application.ts
@@ -5,6 +5,7 @@ import setHeaderButton from "../src/header";
 import fetchNotification from "../src/notification";
 import setRecommendButton from "../src/recommend";
 import setPagination from "../src/pagination";
+import setInfiniteScroll from "../src/infinite_scroll";
 import setUserButtons from "../src/users";
 
 window.addEventListener("DOMContentLoaded", (event) => {
@@ -12,5 +13,6 @@ window.addEventListener("DOMContentLoaded", (event) => {
   fetchNotification();
   setRecommendButton();
   setPagination();
+  setInfiniteScroll();
   setUserButtons();
 });

--- a/app/frontend/src/infinite_scroll.ts
+++ b/app/frontend/src/infinite_scroll.ts
@@ -1,0 +1,64 @@
+import { setFollowIcons } from './follow_icon';
+import { setLikeButtons } from './nweets';
+import { setTagButtons } from './tags';
+
+export default function setInfiniteScroll() {
+  let container = document.getElementById('infiniteScrollContainer');
+
+  if (container) {
+    const fetchOptions: RequestInit = {
+      method: 'GET',
+      mode: 'same-origin',
+      credentials: 'same-origin',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      }
+    }
+
+    const observerOptions = {
+      root: null,
+      rootMargin: '240px',
+      threshold: [1.0]
+    };
+
+    let isLoading = false;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (isLoading) {
+        return;
+      }
+
+      isLoading = true;
+      let morePostsUrl = new URL(location.href);
+      const lastNweet = document.querySelector('.nweets-list').lastElementChild;
+      morePostsUrl.searchParams.set('before', lastNweet.id.slice(5));
+
+      for (const e of entries) {
+        if (morePostsUrl.href) {
+          fetch(morePostsUrl.href, fetchOptions).then((response) => {
+            return response.text();
+          }).then((partial: string) => {
+            let timelineContainer = document.querySelector('.nweets-list');
+            // なぜか表示するヌイートもうないときにresponse.text()は半角空白を返す
+            if (!partial || partial == " ") {
+              observer.unobserve(document.querySelector('#infiniteScrollContainer'));
+            } else {
+              timelineContainer.insertAdjacentHTML('beforeend', partial);
+            }
+          });
+        }
+      }
+      setFollowIcons();
+      setLikeButtons();
+      setTagButtons();
+
+      isLoading = false;
+    }, observerOptions);
+
+    observer.observe(document.querySelector('#infiniteScrollContainer'));
+  } else {
+    setFollowIcons();
+    setLikeButtons();
+    setTagButtons();
+  }
+}

--- a/app/views/pages/_timeline.html.slim
+++ b/app/views/pages/_timeline.html.slim
@@ -3,7 +3,6 @@
     /.nweet-count タイムライン
     ol.nweets-list
       = render @feed_items
-    #willPaginateContainer
-      .d-none = will_paginate @feed_items
+    #infiniteScrollContainer
   - else
     p まだヌイートはありません(T_T)


### PR DESCRIPTION
close #112

単に個数をずらしていくページング処理だと難しそうだったので、最後のヌイートより古いものを取得する処理を実装してみました

流れとしてはフロント側でDOMから取得した最も古いヌイートのIDをパラメータで渡して、そのヌイートより古いものを描画するような形です

ID取得がDOMに依存してたり、コントローラーの分岐があまりエレガントではないですが、問題がなさそうなら他の箇所も実装していきます

それからページング処理に関する部分は、おそらく無限スクロールを実装する前の名残のように見えたので、特に残さずに取り除きました