### PR TITLE
投稿画面のレイアウトをタイムラインに合わせる

### DIFF
--- a/app/views/nweets/new.html.slim
+++ b/app/views/nweets/new.html.slim
@@ -4,7 +4,7 @@
   .row
     .d-none.d-md-block.col-md-3
       = render 'users/user_info', {user: current_user}
-    .col-md-6.p-0
+    .col.p-0
       = render 'nweets/new_form'
       = render 'pages/timeline'
     .d-none.d-lg-block.col-lg-3


### PR DESCRIPTION
投稿画面とタイムラインでレイアウトが異なるので、タイムラインに合わせる

おそらく投稿画面のみ #119 で変更し忘れたもの

現状
![image](https://user-images.githubusercontent.com/65934004/83225684-482bae80-a1bb-11ea-81bc-4f8fa4e20d01.png)
![image](https://user-images.githubusercontent.com/65934004/83225693-4e218f80-a1bb-11ea-83b1-5f8a68d297a4.png)

