### PR TITLE
Turbolinksを再導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'bcrypt_pbkdf'
 
 gem 'slim-rails'
 gem 'html2slim'
+gem 'turbolinks', '~> 5.2.0'
 
 gem 'bootstrap', '>= 4.3.1'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,9 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    turbolinks (5.2.1)
+      turbolinks-source (~> 5.2)
+    turbolinks-source (5.2.0)
     twitter (7.0.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -410,6 +413,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
+  turbolinks (~> 5.2.0)
   twitter
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,9 +15,10 @@
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets
+//= require turbolinks
 //= require_tree .
 
-document.addEventListener('DOMContentLoaded', function(){
+document.addEventListener('turbolinks:load', function () {
   $('[data-toggle="tooltip"]').tooltip();
 });
 //= require serviceworker-companion

--- a/app/frontend/packs/application.ts
+++ b/app/frontend/packs/application.ts
@@ -10,7 +10,7 @@ import { setFollowIcons } from "../src/follow_icon";
 import { setLikeButtons } from "../src/nweets";
 import { setTagButtons } from "../src/tags";
 
-window.addEventListener("DOMContentLoaded", (event) => {
+window.addEventListener("turbolinks:load", (event) => {
   setHeaderButton();
   fetchNotification();
   setRecommendButton();


### PR DESCRIPTION
以前タイムラインのスクロールやいいね処理でコケまくってたときにturbolinksを外したのですが、
#171 とかで直った気がするので再導入しようかと思ってます。

早くなる代わりにイベントの発火タイミングとかが厄介になるので、マージは少し慎重に検討してからにします