### PR TITLE
無限スクロールに関する処理をRails側に移動

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,11 +7,11 @@ class PagesController < ApplicationController
       if params[:before]
         date = Time.at(params[:before].to_i)
         @feed_items = current_user.timeline.where('did_at < ?', date).limit(10)
-        @before = @feed_items.last&.did_at.to_i
+        @before = @feed_items.last&.did_at&.to_i
         render partial: 'nweets/nweets'
       else
         @feed_items = current_user.timeline.limit(10)
-        @before = @feed_items.last&.did_at.to_i
+        @before = @feed_items.last&.did_at&.to_i
       end
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,11 +5,13 @@ class PagesController < ApplicationController
       @timeline = true
 
       if params[:before]
-        @before = Nweet.find_by(url_digest: params[:before])
-        @feed_items = current_user.timeline.where('did_at < ?', @before.did_at).limit(10)
-        render partial: 'nweets/nweet', collection: @feed_items
+        date = Time.at(params[:before].to_i)
+        @feed_items = current_user.timeline.where('did_at < ?', date).limit(10)
+        @before = @feed_items.last&.did_at.to_i
+        render partial: 'nweets/nweets'
       else
         @feed_items = current_user.timeline.limit(10)
+        @before = @feed_items.last&.did_at.to_i
       end
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,7 +5,7 @@ class PagesController < ApplicationController
       @timeline = true
 
       if params[:before]
-        date = Time.at(params[:before].to_i)
+        date = Time.zone.at(params[:before].to_i)
         @feed_items = current_user.timeline.where('did_at < ?', date).limit(10)
         @before = @feed_items.last&.did_at&.to_i
         render partial: 'nweets/nweets'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,7 +53,7 @@ class UsersController < ApplicationController
 
     def render_nweets(nweets, query)
       if params[:before]
-        date = Time.at(params[:before].to_i)
+        date = Time.zone.at(params[:before].to_i)
         @feed_items = nweets.where(query, date).limit(10)
         @before = @feed_items.last&.did_at&.to_i
         render partial: 'nweets/nweets'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,11 +53,13 @@ class UsersController < ApplicationController
 
     def render_nweets(nweets, query)
       if params[:before]
-        before = Nweet.find_by(url_digest: params[:before])
-        @feed_items = nweets.where(query, before.did_at).limit(10)
-        render partial: 'nweets/nweet', collection: @feed_items
+        date = Time.at(params[:before].to_i)
+        @feed_items = nweets.where(query, date).limit(10)
+        @before = @feed_items.last&.did_at.to_i
+        render partial: 'nweets/nweets'
       else
         @feed_items = nweets.limit(10)
+        @before = @feed_items.last&.did_at.to_i
       end
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,11 +55,11 @@ class UsersController < ApplicationController
       if params[:before]
         date = Time.at(params[:before].to_i)
         @feed_items = nweets.where(query, date).limit(10)
-        @before = @feed_items.last&.did_at.to_i
+        @before = @feed_items.last&.did_at&.to_i
         render partial: 'nweets/nweets'
       else
         @feed_items = nweets.limit(10)
-        @before = @feed_items.last&.did_at.to_i
+        @before = @feed_items.last&.did_at&.to_i
       end
     end
 end

--- a/app/views/nweets/_nweets.slim
+++ b/app/views/nweets/_nweets.slim
@@ -1,3 +1,3 @@
 = render @feed_items
-- if not @before.zero?
+- unless @before.nil?
   #infiniteScrollContainer data-before=@before

--- a/app/views/nweets/_nweets.slim
+++ b/app/views/nweets/_nweets.slim
@@ -1,3 +1,3 @@
 = render @feed_items
-- unless @before.nil?
+- if @before
   #infiniteScrollContainer data-before=@before

--- a/app/views/nweets/_nweets.slim
+++ b/app/views/nweets/_nweets.slim
@@ -1,0 +1,3 @@
+= render @feed_items
+- if not @before.zero?
+  #infiniteScrollContainer data-before=@before

--- a/app/views/pages/_likeline.html.slim
+++ b/app/views/pages/_likeline.html.slim
@@ -4,7 +4,6 @@
       = @user.liked_nweets.count
       | 件のいいね
     ol.nweets-list
-      = render @feed_items
-    #infiniteScrollContainer
+      = render "nweets/nweets"
   - else
     p まだ「いいね！」した投稿はありません (T_T)

--- a/app/views/pages/_timeline.html.slim
+++ b/app/views/pages/_timeline.html.slim
@@ -2,7 +2,6 @@
   - if current_user.nweets.any?
     /.nweet-count タイムライン
     ol.nweets-list
-      = render @feed_items
-    #infiniteScrollContainer
+      = render "nweets/nweets"
   - else
     p まだヌイートはありません(T_T)

--- a/app/views/users/_feed.html.slim
+++ b/app/views/users/_feed.html.slim
@@ -4,7 +4,6 @@
       = @user.nweets.count
       | 件のヌイート
     ol.nweets-list
-      = render @feed_items
-    #infiniteScrollContainer
+      = render "nweets/nweets"
   - else
     p まだヌイートはありません (T_T)


### PR DESCRIPTION
ページで1つのinfiniteScrollContainerを使い回す代わりに、描画ごとにinfiniteScrollContainerを出力して、それと置き換える形で読み込むことによって、クエリをRailsのView側から属性を介して出来るようにした

なるべく念入りに調査した限りは特に問題はなさそうだったけど、割と複雑な変更だからエッジケースで問題が起きる可能性はありそう

今の所分かっている動作の違いは、変更前は20件ずつ読み込んでいたのが10件ずつになって、スクロール時に底に着く回数が増えた。UX的にobserverのmarginを増やすか、読み込む件数を増やしたほうが良いかも

原因としてはIntersectionObserverが初回と見えなくなったタイミングでもcallbackを実行しているみたいで、毎回containerを置き換えると読み込みが止まらなくなってしまうから、見えているときだけに制限した