### PR TITLE
tsconfig.jsonのlib指定をes2019にする

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,18 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "lib": ["es6", "dom"],
+    "lib": [
+      "es2019",
+      "dom",
+    ],
     "module": "es6",
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-        "*": ["node_modules/*", "app/javascript/*"]
+      "*": [
+        "node_modules/*",
+        "app/frontend/*",
+      ]
     },
     "sourceMap": true,
     "target": "es5"
@@ -17,7 +23,7 @@
     "**/*.spec.ts",
     "node_modules",
     "vendor",
-    "public"
+    "public",
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
本番でtsのコンパイルに失敗してるなと思ったら、ES6以降の文法を使ってるのにtsconfig.json更新できてないのが原因らしいので、更新する

基本的にWebpackerが生成した初期設定に乗っかるようにしてるけど、適宜自分たちで変更を入れてかなきゃだめっぽい