### PR TITLE
レイアウトが崩れているのを修正

### DIFF
--- a/app/views/nweets/show.html.slim
+++ b/app/views/nweets/show.html.slim
@@ -6,7 +6,7 @@
   .row
     .col-md-3
       = render 'users/user_info', {user: @nweet.user}
-    .col.p-0
+    .col-md.p-0
       .nweet-feed.row_top
         ol.nweets-list
           = render @nweet

--- a/app/views/users/likes.html.slim
+++ b/app/views/users/likes.html.slim
@@ -4,7 +4,7 @@
   .row
     .d-md-block.col-md-3
       = render 'users/user_info', {user: @user}
-    .col.p-0
+    .col-md.p-0
       = render 'pages/likeline'
     .d-none.d-lg-block.col-lg-3
       = render 'pages/recommend'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,7 +3,7 @@
   .row
     .col-md-3
       = render 'users/user_info', {user: @user}
-    .col.p-0
+    .col-md.p-0
       = render 'users/feed'
     .d-none.d-lg-block.col-lg-3
       = render 'pages/recommend'

--- a/app/views/users/show_follow.html.slim
+++ b/app/views/users/show_follow.html.slim
@@ -4,7 +4,7 @@
   .row
     .d-md-block.col-md-3
       = render 'users/user_info', {user: @user}
-    .col.p-0.nweet-feed.row_top
+    .col-md.p-0.nweet-feed.row_top
       - if @users.any?
         .nweet-count
           = @users.count


### PR DESCRIPTION
fix #193

なぜかbootstrap 4.5.0から`.col-md-3`と`.col`が並ぶとレイアウトが崩れるみたい

色々試してみたら`.col`の代わりに`.col-md`を使うと崩れなくなったから、見つけた限りは修正した

bootstrap的に何が正しいのか、それとも単なるバグなのかよく分からない

もしかしたら他にも崩れてるページがあるかも