### PR TITLE
ログインフォームとかが右にずれるのを修正

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -630,7 +630,7 @@ a {
 
 @media screen and (min-width: 766px) {
   .not-so-jumbo {
-    width: 766px;
+    max-width: 766px;
   }
 
   .side-section {


### PR DESCRIPTION
ログインページのほかに新規登録ページと、プロフィール編集ページのズレが修正された

before
![image](https://user-images.githubusercontent.com/65934004/84633439-5a337e00-af2b-11ea-8bfc-398862adc31a.png)
after
![image](https://user-images.githubusercontent.com/65934004/84633461-63244f80-af2b-11ea-860d-52e3fd6df7c7.png)
