### PR TITLE
Capistranoをアップデート、バージョン固定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'capistrano'
+  gem 'capistrano', '3.14.1'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano-rbenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,7 +371,7 @@ DEPENDENCIES
   bootstrap (>= 4.3.1)
   byebug
   camo
-  capistrano
+  capistrano (= 3.14.1)
   capistrano-bundler
   capistrano-rails
   capistrano-rake

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 require File.expand_path("./environment", __dir__)
 
 # capistranoのバージョン固定
-lock "3.13.0"
+lock "3.14.1"
 
 # デプロイするアプリケーション名
 set :application, 'nuita'


### PR DESCRIPTION
- CapistranoのバージョンとCapfileの指定が不整合してたので修正
- 致命的なあれにならない限りしばらくGemfileで固定しちゃう