### PR TITLE
ヌイート詳細画面からタグ一覧をいじれるようにする

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,16 +2,16 @@ class TagsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    link = Link.find(params[:link_id])
-    link.set_tag(params[:tag_name])
+    link = Link.find(params[:link])
+    link.set_tag(params[:name])
 
-    redirect_back(fallback_location: root_path)
+    render partial: 'cards/renew_modal_tags', locals: {link: link}
   end
 
   def destroy
-    link = Link.find(params[:link_id])
-    link.remove_tag(params[:tag_name])
+    link = Link.find(params[:link])
+    link.remove_tag(params[:name])
 
-    redirect_back(fallback_location: root_path)
+    render partial: 'cards/renew_modal_tags', locals: {link: link}
   end
 end

--- a/app/views/cards/_edit_modal.html.slim
+++ b/app/views/cards/_edit_modal.html.slim
@@ -15,11 +15,8 @@
               = icon 'fas', 'plus'
         h6.mb-2 既存のタグ
         - link.tags.pluck(:name).each do |tag_name|
-          .input-group.mb-2
-            .btn.btn-sm.btn-secondary
-              span.pr-2 = tag_name
-              = icon 'fas', 'times'
-      .modal-footer
-        .btn.btn-outline-secondary data-dismiss="modal" 閉じる
+          .btn.btn-sm.btn-secondary.mr-2.mb-2
+            span.pr-2 = tag_name
+            = icon 'fas', 'times'
 
     

--- a/app/views/cards/_edit_modal.html.slim
+++ b/app/views/cards/_edit_modal.html.slim
@@ -6,17 +6,14 @@
         button.close type="buttton" data-dismiss="modal"
           span &times;
       .modal-body
-        .input-group.mb-4
-          .input-group-prepend
-            span.input-group-text = icon 'fas', 'hashtag'
-          = text_field_tag 'tag_name', nil, {placeholder: 'タグ名', class: 'form-control'}
-          .input-group-append
-            = button_tag type: 'button', class: 'btn btn-brandcolor' do
-              = icon 'fas', 'plus'
+        = form_with url: tag_path(link: link), remote: true do |f|  
+          .input-group.mb-4
+            .input-group-prepend
+              span.input-group-text = icon 'fas', 'hashtag'
+            = f.text_field :name, {placeholder: 'タグ名', class: 'form-control'}
+            .input-group-append
+              = f.submit class: 'btn btn-brandcolor' do
+                = icon 'fas', 'plus'
         h6.mb-2 既存のタグ
-        - link.tags.pluck(:name).each do |tag_name|
-          .btn.btn-sm.btn-secondary.mr-2.mb-2
-            span.pr-2 = tag_name
-            = icon 'fas', 'times'
-
-    
+        .edit-modal-tag-list id="editModalTagList#{link.id}"
+          = render 'cards/edit_modal_tags', link: link

--- a/app/views/cards/_edit_modal.html.slim
+++ b/app/views/cards/_edit_modal.html.slim
@@ -1,0 +1,25 @@
+.modal tabindex="-1" role="dialog" id="cardEditModal#{link.id}"
+  .modal-dialog.modal-dialog-centered
+    .modal-content
+      .modal-header
+        h5.modal-title タグを編集
+        button.close type="buttton" data-dismiss="modal"
+          span &times;
+      .modal-body
+        .input-group.mb-4
+          .input-group-prepend
+            span.input-group-text = icon 'fas', 'hashtag'
+          = text_field_tag 'tag_name', nil, {placeholder: 'タグ名', class: 'form-control'}
+          .input-group-append
+            = button_tag type: 'button', class: 'btn btn-brandcolor' do
+              = icon 'fas', 'plus'
+        h6.mb-2 既存のタグ
+        - link.tags.pluck(:name).each do |tag_name|
+          .input-group.mb-2
+            .btn.btn-sm.btn-secondary
+              span.pr-2 = tag_name
+              = icon 'fas', 'times'
+      .modal-footer
+        .btn.btn-outline-secondary data-dismiss="modal" 閉じる
+
+    

--- a/app/views/cards/_edit_modal_tags.html.slim
+++ b/app/views/cards/_edit_modal_tags.html.slim
@@ -1,4 +1,5 @@
 - link.tags.pluck(:name).each do |tag_name|
-  .btn.btn-sm.btn-secondary.mr-2.mb-2
-    span.pr-2 = tag_name
-    = icon 'fas', 'times'
+  = link_to tag_path(link: link, name: tag_name), {method: :delete, remote: true} do
+    .btn.btn-sm.btn-secondary.mr-2.mb-2
+      span.pr-2 = tag_name
+      = icon 'fas', 'times'

--- a/app/views/cards/_edit_modal_tags.html.slim
+++ b/app/views/cards/_edit_modal_tags.html.slim
@@ -1,0 +1,4 @@
+- link.tags.pluck(:name).each do |tag_name|
+  .btn.btn-sm.btn-secondary.mr-2.mb-2
+    span.pr-2 = tag_name
+    = icon 'fas', 'times'

--- a/app/views/cards/_renew_modal_tags.js.slim
+++ b/app/views/cards/_renew_modal_tags.js.slim
@@ -1,2 +1,2 @@
-var div = "editModalTagList#{link.id}"
-document.getElementById(div).innerHTML = "#{j render('cards/edit_modal', locals: {link: link})}"
+| var div = "editModalTagList#{link.id}";
+| document.getElementById(div).innerHTML = "#{j render(partial: 'cards/edit_modal_tags', locals: {link: link})}";

--- a/app/views/cards/_renew_modal_tags.js.slim
+++ b/app/views/cards/_renew_modal_tags.js.slim
@@ -1,0 +1,2 @@
+var div = "editModalTagList#{link.id}"
+document.getElementById(div).innerHTML = "#{j render('cards/edit_modal', locals: {link: link})}"

--- a/app/views/cards/_tags.html.slim
+++ b/app/views/cards/_tags.html.slim
@@ -6,7 +6,9 @@
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = tag
         span.small.delete_icon = icon 'fas', tag_icon(is_tagged)
-  button class="badge badge-tag mx-1" data-toggle="modal" data-target="#cardEditModal#{link.id}"
-    span.small = icon 'fas', 'plus'
+  - if user_signed_in?
+    button class="badge badge-tag mx-1" data-toggle="modal" data-target="#cardEditModal#{link.id}"
+      span.small = icon 'fas', 'plus'
 
-= render 'cards/edit_modal', link: link
+- if user_signed_in?
+  = render 'cards/edit_modal', link: link

--- a/app/views/cards/_tags.html.slim
+++ b/app/views/cards/_tags.html.slim
@@ -1,8 +1,12 @@
-.mt-0.mb-2
+.tag-link.nweet-tag-link.mt-0.mb-2
   - visible_tags.each do |tag|
     - is_tagged = link.tags.exists?(name: tag)
-    = link_to tag_path(link_id: link.id, tag_name: tag), method: tag_method(is_tagged), class: 'tag-link nweet-tag-link' do
+    = link_to tag_path(link_id: link.id, tag_name: tag), method: tag_method(is_tagged) do
       span class="badge badge-tag mx-1 #{'active' if is_tagged = link.tags.exists?(name: tag)}"
         span.small = icon 'fas', 'hashtag'
         span.pr-1 = tag
         span.small.delete_icon = icon 'fas', tag_icon(is_tagged)
+  button class="badge badge-tag mx-1" data-toggle="modal" data-target="#cardEditModal#{link.id}"
+    span.small = icon 'fas', 'plus'
+
+= render 'cards/edit_modal', link: link

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -1,4 +1,36 @@
 require 'test_helper'
 
 class TagsControllerTest < ActionDispatch::IntegrationTest
+  include Warden::Test::Helpers
+
+  def setup
+    Warden.test_mode!
+    
+    @user = users(:chikuwa)
+    @link = links(:kanikama)
+  end
+
+  test 'should not create tags unless log in' do
+    assert_no_difference 'LinkTag.count' do
+      post tag_path(link: @link, name: '巨乳'), xhr: true
+    end
+  end
+
+  test 'should not delete tags unless log in' do
+    assert_no_difference 'LinkTag.count' do
+      delete tag_path(link: @link, name: 'R18G'), xhr: true
+    end
+  end
+
+  test 'create tags' do
+    login_as(@user)
+    post tag_path(link: @link, name: '巨乳'), xhr: true
+    assert @link.tags.exists?(name: '巨乳')
+  end
+
+  test 'delete tags' do
+    login_as(@user)
+    delete tag_path(link: @link, name: 'R18G'), xhr: true
+    assert_not @link.tags.exists?(name: 'R18G')
+  end
 end

--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -1,5 +1,10 @@
 kanikama:
   url: 'https://www.pixiv.net/artworks/59554738'
+  title: 'ツイッター絵詰め'
+  description: '色々詰めVer'
+  image: 'https://pixiv.cat/59554738-1.jpg'
+  image_width: 700
+  image_height: 480
 
 kemo:
   url: 'https://twitter.com/aoi_nishimata/status/831825876899635200'


### PR DESCRIPTION
<s>現状見た目だけできてる状態</s> うごく close: #200 

<img width="576" alt="スクリーンショット 2020-06-24 23 03 09" src="https://user-images.githubusercontent.com/19870474/85571178-e736af80-b66e-11ea-8dc3-0fbbbefa44e8.png">

実際のカードを見ながらいじれるようにしようと思ったけど、モーダルでやると領域足りなくて大変かもしれない
- とりあえずプレビュー無しでタグ一覧だけ表示されるようにした