### PR TITLE
R18Gと3D用のUIを削除、検閲するタグを設定画面から選択できるようにする

### DIFF
--- a/app/controllers/censorings_controller.rb
+++ b/app/controllers/censorings_controller.rb
@@ -1,22 +1,15 @@
 class CensoringsController < ApplicationController
-  include TagsHelper
-
   before_action :authenticate_user!
 
-  def update
-    begin
-      visible_tags.each do |tag_name|
-        if current_user.censoring?(tag_name)
-          current_user.uncensor(tag_name) if params[tag_name] == '0'
-        else
-          current_user.censor(tag_name) if params[tag_name] == '1'
-        end
-      end
-      flash[:success] = '検閲カテゴリの設定に成功しました'
-    rescue => e
-      flash[:danger] = "検閲カテゴリの設定に失敗しました: #{e}"
-    ensure
-      redirect_to edit_user_registration_path(current_user)
-    end
+  def create
+    current_user.censor(params[:tag])
+
+    render partial: 'devise/registrations/renew_modal_tags', locals: {tags: current_user.censored_tags}
+  end
+
+  def destroy
+    current_user.uncensor(params[:tag])
+
+    render partial: 'devise/registrations/renew_modal_tags', locals: {tags: current_user.censored_tags}
   end
 end

--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -20,9 +20,6 @@ class NweetsController < ApplicationController
     @nweet = current_user.nweets.build(new_nweet_params)
     if @nweet.save
       flash[:success] = 'ヌイートを投稿しました！'
-      if @nweet.links.any?
-        set_tags(@nweet.links.first)
-      end
       tweet if current_user.autotweet_enabled
     else
       flash[:danger] = @nweet.errors.full_messages
@@ -69,12 +66,5 @@ class NweetsController < ApplicationController
     def correct_user
       @nweet = current_user.nweets.find_by(url_digest: params[:url_digest])
       redirect_to root_url if @nweet.nil?
-    end
-
-    def set_tags(link)
-      # 正直カテゴリーの中身mass assignmentされても何の脆弱性もないたぶん
-      params.permit(tags: {}).to_hash["tags"].each do |tag_name, value|
-        link.set_tag(tag_name) if value == '1'
-      end
     end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -8,11 +8,6 @@ module TagsHelper
     end
   end
 
-  # R18G, 3D以外のタグは現状表示しない
-  def visible_tags
-    ['3D', 'R18G']
-  end
-
   def tag_method(is_existing)
     if is_existing
       :delete

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,8 +95,8 @@ class User < ApplicationRecord
 
   # censor, uncensor, censoring? can take both instances of String and Tag
   def censor(tag)
-    if tag.instance_of?(String)
-      tag = Tag.find_by(name: tag)
+    unless tag.instance_of?(Tag)
+      tag = Tag.find_or_create_by(name: tag.upcase)
     end
 
     self.censored_tags << tag

--- a/app/views/cards/_edit_modal.html.slim
+++ b/app/views/cards/_edit_modal.html.slim
@@ -12,8 +12,7 @@
               span.input-group-text = icon 'fas', 'hashtag'
             = f.text_field :name, {placeholder: 'タグ名', class: 'form-control'}
             .input-group-append
-              = f.submit class: 'btn btn-brandcolor' do
-                = icon 'fas', 'plus'
+              = f.button icon('fas', 'plus'), type: :submit, class: 'btn btn-brandcolor'
         h6.mb-2 既存のタグ
         .edit-modal-tag-list id="editModalTagList#{link.id}"
           = render 'cards/edit_modal_tags', link: link

--- a/app/views/cards/_tags.html.slim
+++ b/app/views/cards/_tags.html.slim
@@ -5,7 +5,7 @@
       span.pr-1 = tag_name
   - if user_signed_in?
     button class="badge badge-tag mx-1" data-toggle="modal" data-target="#cardEditModal#{link.id}"
-      span.small = icon 'fas', 'plus'
+      span.small = icon 'fas', 'pencil-alt'
       
 - if user_signed_in?
   = render 'cards/edit_modal', link: link

--- a/app/views/cards/_tags.html.slim
+++ b/app/views/cards/_tags.html.slim
@@ -1,16 +1,8 @@
 .tag-link.nweet-tag-link.mt-0.mb-2
-  - visible_tags.each do |tag|
-    - is_tagged = link.tags.exists?(name: tag)
-    = link_to tag_path(link_id: link.id, tag_name: tag), method: tag_method(is_tagged) do
-      span class="badge badge-tag mx-1 #{'active' if is_tagged}"
-        span.small = icon 'fas', 'hashtag'
-        span.pr-1 = tag
-        span.small.delete_icon = icon 'fas', tag_icon(is_tagged)
   - link.tags.pluck(:name).each do |tag_name|
-    - unless visible_tags.include?(tag_name)
-      span.badge.badge-light.badge-tag.mx-1.active
-        span.small = icon 'fas', 'hashtag'
-        span.pr-1 = tag_name
+    span.badge.badge-light.badge-tag.mx-1.active
+      span.small = icon 'fas', 'hashtag'
+      span.pr-1 = tag_name
   - if user_signed_in?
     button class="badge badge-tag mx-1" data-toggle="modal" data-target="#cardEditModal#{link.id}"
       span.small = icon 'fas', 'plus'

--- a/app/views/devise/registrations/_edit_censoring_modal.html.slim
+++ b/app/views/devise/registrations/_edit_censoring_modal.html.slim
@@ -1,0 +1,18 @@
+.modal tabindex="-1" role="dialog" id="editCensoringModal"
+  .modal-dialog.modal-dialog-centered
+    .modal-content
+      .modal-header
+        h5.modal-title 非表示にするタグを編集
+        button.close type="buttton" data-dismiss="modal"
+          span &times;
+      .modal-body
+        = form_with url: censoring_path, remote: true do |f|  
+          .input-group.mb-4
+            .input-group-prepend
+              span.input-group-text = icon 'fas', 'hashtag'
+            = f.text_field :tag, {placeholder: 'タグ名', class: 'form-control'}
+            .input-group-append
+              = f.button icon('fas', 'plus'), type: :submit, class: 'btn btn-brandcolor'
+        h6.mb-2 既存のタグ
+        .edit-modal-tag-list id="editCensoringModalTagList"
+          = render 'edit_censoring_modal_tags', tags: current_user.censored_tags

--- a/app/views/devise/registrations/_edit_censoring_modal_tags.html.slim
+++ b/app/views/devise/registrations/_edit_censoring_modal_tags.html.slim
@@ -1,0 +1,5 @@
+- tags.pluck(:name).each do |tag_name|
+  = link_to censoring_path(tag: tag_name), {method: :delete, remote: true} do
+    .btn.btn-sm.btn-secondary.mr-2.mb-2
+      span.pr-2 = tag_name
+      = icon 'fas', 'times'

--- a/app/views/devise/registrations/_renew_modal_tags.js.slim
+++ b/app/views/devise/registrations/_renew_modal_tags.js.slim
@@ -1,0 +1,2 @@
+| var div = "editCensoringModalTagList";
+| document.getElementById(div).innerHTML = "#{j render(partial: 'devise/registrations/edit_censoring_modal_tags', locals: {tags: tags})}";

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -88,13 +88,8 @@
     - if current_user.twitter_screen_name.nil?
       p = link_to "twitterアカウントを登録", "/auth/twitter", class: "btn btn-twitter", method: :post
     h3.pt-4 その他のオプション
-    h5 検閲カテゴリ
-    = form_with url: censoring_path(current_user), method: :put, class: "form-group", local: true do |f|
-      .form-group
-        - visible_tags.each do |tag_name|
-          .form-check.form-check-inline
-            = f.check_box "#{tag_name}", {:checked => current_user.censoring?(tag_name), class: 'form-check-input'}
-            label.form-check-label = tag_name
-        = f.submit "検閲カテゴリを更新", class: 'btn btn-follow'
+    button class="btn btn-follow" data-toggle="modal" data-target="#editCensoringModal"
+      span.small 検閲カテゴリを編集
+    = render 'edit_censoring_modal'
     p = button_to "アカウント削除", registration_path(resource_name), data: { confirm: "本当にアカウントを削除しますか？" }, method: :delete, class: "btn btn-danger"
     = link_to "戻る", :back

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -3,15 +3,6 @@
     = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita wider-margintop"
   .row.mx-2.mx-md-0
     = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力', value: params[:text]
-  .row.mx-2.mx-md-0
-    .col.form-check.form-check-inline
-      - visible_tags.each do |tag|
-        = button_tag type: 'button', class: 'toggle-tag-link tag-link not-button' do
-          span class="badge badge-tag mx-1"
-            span.small = icon 'fas', 'hashtag'
-            span.pr-1 = tag
-            span.small.delete_icon = icon 'fas', 'plus'
-          = hidden_field_tag "tags[#{tag}]", 0
   = f.hidden_field :did_at, value: @nweet.did_at
   .row.mx-2.mx-md-0
     = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,6 @@ Rails.application.routes.draw do
   resource :tag, only: [:create, :destroy]
   resource :like, only: [:create, :destroy]
   resource :link, only: [:create]
-  resource :censoring, only: [:update]
+  resource :censoring, only: [:create, :destroy]
   resource :relationship, only: [:create, :destroy]
 end

--- a/test/controllers/censorings_controller_test.rb
+++ b/test/controllers/censorings_controller_test.rb
@@ -8,12 +8,22 @@ class CensoringsControllerTest < ActionDispatch::IntegrationTest
     @user = users(:chikuwa)
   end
 
-  test "editing censoring require log in" do
-    put censoring_path, params: {'r18g': '0', '3d': '0'}
-    assert_redirected_to new_user_session_url
+  test 'can add and delete censoring' do
+    assert_no_difference 'Preference.count' do
+      post censoring_path(tag: 'ふたなり'), xhr: true
+    end
 
     login_as(@user)
-    put censoring_path, params: {'r18g': '0', '3d': '0'}
-    assert_redirected_to edit_user_registration_path(@user) # とりあえず成功してるってことで……
+    post censoring_path(tag: 'ふたなり'), xhr: true
+    assert @user.censoring?('ふたなり')
+
+    delete censoring_path(tag: 'ふたなり'), xhr: true
+    assert_not @user.censoring?('ふたなり')
+  end
+
+  test 'cannot delete censoring when not logged-in' do
+    assert_no_difference 'Preference.count' do
+      delete censoring_path(tag: 'R18G'), xhr: true
+    end
   end
 end

--- a/test/controllers/nweets_controller_test.rb
+++ b/test/controllers/nweets_controller_test.rb
@@ -66,14 +66,4 @@ class NweetsControllerTest < ActionDispatch::IntegrationTest
     @friend_nweet.reload
     assert_not_equal '誰だ今の', @friend_nweet.statement
   end
-
-  test 'can set tags when create nweet' do
-    login_as(@user)
-
-    gro_url = 'https://dic.pixiv.net/a/R-18G'
-    post nweets_path, params: {nweet: {statement: gro_url, did_at: 1.minute.ago}, tags: {'R18G': '1', '3D': '0'} }
-    link = Link.find_by(url: gro_url)
-    assert link.tags.exists?(name: 'R18G')
-    assert_not link.tags.exists?(name: '3D')
-  end
 end

--- a/test/integration/censoring_test.rb
+++ b/test/integration/censoring_test.rb
@@ -29,16 +29,11 @@ class CensoringTest < ActionDispatch::IntegrationTest
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseHorizontal#{link.id}", false
 
-    put censoring_path(@user), params: {"R18G": 1, "KEMO": 1}
+    post censoring_path(tag: 'KEMO'), xhr: true
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseHorizontal#{link.id}"
 
-    nweet = nweets(:r18g)
-    link = nweet.links.first
-    get nweet_path(nweet)
-    assert_select "a[href=?]", "#collapseHorizontal#{link.id}"
-
-    put censoring_path(@user), params: {"R18G": "0", "KEMO": "0"}
+    delete censoring_path(tag: 'KEMO'), xhr: true
     get nweet_path(nweet)
     assert_select "a[href=?]", "#collapseHorizontal#{link.id}", false
   end


### PR DESCRIPTION
close #201 

TagsHelper#visible_tagsを削除するのが目標で始めたけど、設定画面もこれに依拠してたからモーダルで作り直すことになった

cards/edit_tag_modalと大部分が似てるから共通化できそう。別のPRで出すかも