### PR TITLE
外部サイトの画像には常にcamo使う

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
 
   # returns camo url only in production mode
   def camo_url(url)
-    if Rails.env.production? && /http:\/\// =~ url
+    if Rails.env.production?
       camo(url)
     else
       url


### PR DESCRIPTION
接続先がhttpsでもキャッシュサーバ代わりにcamo使う close #175 