### PR TITLE
デフォルトの検閲タグを増やす＆一部の名称変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
     popper_js (1.16.0)
     public_suffix (4.0.5)
     puma (3.12.6)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
 
   # returns camo url only in production mode
   def camo_url(url)
-    if Rails.env.production? && /http:\/\// =~ url
+    if Rails.env.production?
       camo(url)
     else
       url

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,6 +4,8 @@ class Tag < ApplicationRecord
   has_many :link_tags, dependent: :destroy
   has_many :links, through: :link_tags
 
+  has_many :preferences, dependent: :destroy
+
   before_save :set_censored_by_default
   before_validation { name.upcase! }
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,7 +13,7 @@ class Tag < ApplicationRecord
 
     def set_censored_by_default
       # こんなのハードコーディングすべきじゃない気がする
-      censor_list = ['R18G', '3D', 'R-18G', 'スカトロ']
+      censor_list = ['3D', 'R-18G', 'スカトロ']
 
       if censor_list.include?(name)
         self.censored_by_default = true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,7 +10,8 @@ class Tag < ApplicationRecord
   private
 
     def set_censored_by_default
-      censor_list = ['R18G', '3D']
+      # こんなのハードコーディングすべきじゃない気がする
+      censor_list = ['R18G', '3D', 'R-18G', 'スカトロ']
 
       if censor_list.include?(name)
         self.censored_by_default = true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,7 +13,7 @@ class Tag < ApplicationRecord
 
     def set_censored_by_default
       # こんなのハードコーディングすべきじゃない気がする
-      censor_list = ['3D', 'R-18G', 'スカトロ']
+      censor_list = ['R-18G', 'スカトロ']
 
       if censor_list.include?(name)
         self.censored_by_default = true

--- a/lib/tasks/link_task.rake
+++ b/lib/tasks/link_task.rake
@@ -54,4 +54,17 @@ namespace :link_task do
       end
     end
   end
+
+  desc "[temporary] change tag names and censorings"
+  task change_censoring: :environment do
+    Tag.find_by(name: 'R-18G')&.destroy
+    Tag.find_by(name: 'R18G')&.update_attribute(:name, 'R-18G')
+    
+    Tag.find_by(name: '3次元')&.destroy
+    Tag.find_by(name: '3D')&.update_attribute(:name, '3次元')
+
+    User.find_each do |user|
+      user.censor 'スカトロ'
+    end
+  end
 end

--- a/test/models/preference_test.rb
+++ b/test/models/preference_test.rb
@@ -4,6 +4,7 @@ class PreferenceTest < ActiveSupport::TestCase
   def setup
     @user = users(:chikuwa)
     @tag = tags(:r18g)
+    @another_tag = tags(:three_d)
   end
 
   test "user and tag have to be present, but don't have to be unique" do
@@ -18,5 +19,17 @@ class PreferenceTest < ActiveSupport::TestCase
 
     dup_preference = Preference.new(user: @user, tag: @tag)
     assert dup_preference.valid?
+  end
+
+  test 'destroy when tag or user is destroyed' do
+    Preference.create(user: @user, tag: @tag)
+    assert_difference 'Preference.count', -1 do
+      @tag.destroy
+    end
+
+    Preference.create(user: @user, tag: @another_tag)
+    assert_difference 'Preference.count', -1 do
+      @user.destroy
+    end    
   end
 end


### PR DESCRIPTION
外部サイトに合わせてタグの名称を変更、検閲を追加

- 名称変更：R18G→R-18G, 3D→3次元
- 検閲追加：全ユーザーの検閲タグに「スカトロ」追加
- 検閲削除：新規ユーザーからは「3次元」(3D)の検閲外す