### PR TITLE
fix #221

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,19 +95,23 @@ class User < ApplicationRecord
 
   # censor, uncensor, censoring? can take both instances of String and Tag
   def censor(tag)
-    unless tag.instance_of?(Tag)
-      tag = Tag.find_or_create_by(name: tag.upcase)
-    end
+    unless self.censoring?(tag)
+      unless tag.instance_of?(Tag)
+        tag = Tag.find_or_create_by(name: tag.upcase)
+      end
 
-    self.censored_tags << tag
+      self.censored_tags << tag
+    end
   end
 
   def uncensor(tag)
-    if tag.instance_of?(String)
-      tag = Tag.find_by(name: tag)
-    end
+    if self.censoring?(tag)
+      if tag.instance_of?(String)
+        tag = Tag.find_by(name: tag)
+      end
 
-    self.censorings.find_by(tag_id: tag.id).destroy
+      self.censorings.find_by(tag_id: tag.id).destroy
+    end
   end
 
   def add_badge(badge)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -97,7 +97,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.badges.exists?
   end
 
-  test 'censoring must be unique' do
+  test 'cannot censor a tag twice' do
     @user.censor 'ふたなり'
 
     assert_no_difference '@user.censorings.count' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -96,4 +96,12 @@ class UserTest < ActiveSupport::TestCase
     @user.badges.destroy(badge)
     assert_not @user.badges.exists?
   end
+
+  test 'censoring must be unique' do
+    @user.censor 'ふたなり'
+
+    assert_no_difference '@user.censorings.count' do
+      @user.censor 'ふたなり'
+    end
+  end
 end


### PR DESCRIPTION
fix #221 

User.censored_tags の一意性に関する保証がないのは変わらないので、付け焼刃っぽい

Preferenceにマイグレーションで`[user_id, tag_id, type]`みたいなインデックス貼れば解決しそう
現状Preferenceは1つしか持ってなくて検証しづらいので、#204 の設定するときに同時にやります