### PR TITLE
一旦camoの使用をhttpサイトのプロキシに限定する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
 
   # returns camo url only in production mode
   def camo_url(url)
-    if Rails.env.production?
+    if Rails.env.production? && /http:\/\// =~ url 
       camo(url)
     else
       url


### PR DESCRIPTION
camoしばらくはいい感じだったんですが、現状PixivとKomiflo取りにいくの失敗してるみたいです（もしかしたらブロッキングされてるかも）。
[camo自体にキャッシュ機能はない](https://qiita.com/tomoasleep/items/6b50445d5a5eac06f7a8)っぽい話もあるので、一旦camoの使用をhttp画像のプロキシに限定します。

キャッシュ自体は何らかの形でちゃんとやらなきゃいけない……。