### PR TITLE
dockerを導入

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "nuita",
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/app",
+	"settings": {
+		"terminal.integrated.shell.linux": null
+	},
+	"extensions": [],
+	"postCreateCommand": "bundle install && yarn install --check-files",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,6 @@
 	"settings": {
 		"terminal.integrated.shell.linux": null
 	},
-	"extensions": [],
+	"extensions": ["sianglim.slim"],
 	"postCreateCommand": "bundle install && yarn install --check-files",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
-	"name": "nuita",
-	"dockerComposeFile": "../docker-compose.yml",
-	"service": "app",
-	"workspaceFolder": "/app",
-	"settings": {
-		"terminal.integrated.shell.linux": null
-	},
-	"extensions": ["sianglim.slim"],
-	"postCreateCommand": "bundle install && yarn install --check-files",
+  "name": "nuita",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/app",
+  "settings": {
+    "terminal.integrated.shell.linux": null
+  },
+  "extensions": ["sianglim.slim"],
+  "postCreateCommand": "bundle install && yarn install --check-files"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/vendor/bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.6.2
+
+# RUN apt-get update -qq && apt-get install -y build-essential
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update -qq && apt-get install -y nodejs yarn
+
+RUN gem install bundler:2.0.2
+
+WORKDIR /app
+
+ENV PATH $PATH:/app/bin
+
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ruby:2.6.2
 
-# RUN apt-get update -qq && apt-get install -y build-essential
-
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  host: <%= ENV.fetch("MYSQL_HOST", "db") %>
+  host: <%= ENV.fetch("MYSQL_HOST", "localhost") %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  socket: /tmp/mysql.sock
+  host: <%= ENV.fetch("MYSQL_HOST", "db") %>
 
 development:
   <<: *default

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 3000 }, "0.0.0.0"
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }, "0.0.0.0"
+port        ENV.fetch("PORT") { 3000 }, ENV["HOST"]
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - node_modules:/app/node_modules
     environment:
       BUNDLE_PATH: vendor/bundle
+      HOST: 0.0.0.0
     depends_on:
       - db
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - node_modules:/app/node_modules
     environment:
       BUNDLE_PATH: vendor/bundle
+      MYSQL_HOST: db
       HOST: 0.0.0.0
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+      - bundle:/app/vendor/bundle
+      - node_modules:/app/node_modules
+    environment:
+      BUNDLE_PATH: vendor/bundle
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+    command: /bin/sh -c "while sleep 1000; do :; done"
+
+  db:
+    image: mysql
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    ports:
+      - "3306:3306"
+    volumes:
+      - "database:/var/lib/mysql"
+    command: --default-authentication-plugin=mysql_native_password
+
+volumes:
+  bundle:
+  node_modules:
+  database:


### PR DESCRIPTION
close #241

### 変えたもの
  - bundleのインストール先にvendor/bundleを指定
    - プロジェクトディレクトリに入れることでホスト側と共有してキャッシュさせるため
  - 依存ツールのバージョンの変更
    - Node.js, yarnはバージョンが不明なので最新安定版に、mysqlはdockerレジストリから取ってくるため8系の最新に
  - docker外からアクセスするためにrailsが起動するデフォルトのホストを0.0.0.0にした

### 開発方法
  - VSCode Remote Developmentを使う方法（おすすめ）
    - VSCodeに[Remote Containers https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers]拡張機能をインストールする
    - プロジェクトを開いて、右下に出てくるポップアップのReopen in Containerボタンをクリック
      - またはコマンドパレットからRemote-Containers: Reopen in Containerを選択
    - 環境構築が自動で行われるのでしばらく待つ
      - nuita[/ bundleとnuita]node_modulesボリュームに予めコピーしておけばインストールが早くなるかも
    - VSCodeのターミナルからRailsを起動する
      - bundle installとyarn installは済んでるので、データベースのセットアップからやつ
        - $ rails db:setup
      - 予めnuita_databaseボリュームにコピーしておけば省略できるはず
      - $ rails s
  - 自力でやる方法
    - `docker-compose up -d`でコンテナを起動する
    - `docker-compose exec app bash`でコンテナに入る
      - ボリュームに関しては上と同じ
      - `bundle install && yarn install --check-files`
      - `rails db:setup`
      - `rails s`
    - `docker-compose down`でコンテナを終了する
