### PR TITLE
CIで使用するnodejsのバージョンを上げる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
         ruby-version: 2.6.2
     - name: Install dependencies
       run: |
-        sudo apt install -y yarn nodejs
+        curl -sL https://deb.nodesource.com/setup_10.x | bash - && sudo apt install -y nodejs
+        sudo apt install -y yarn
         yarn install --check-files
         bundle install --path vendor/bundle
     - name: Set Database


### PR DESCRIPTION
> ActionView::Template::Error: Autoprefixer doesn’t support Node v8.10.0. Update it.

って出るため
