### PR TITLE
imageproxyを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'faker'
 gem "nokogiri", ">= 1.10.4"
 gem 'valid_url'
 gem 'fastimage'
-gem 'camo'
 gem 'panchira'
 
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     buftok (0.2.0)
     builder (3.2.4)
     byebug (11.1.3)
-    camo (0.1.0)
     capistrano (3.14.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -361,7 +360,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (>= 4.3.1)
   byebug
-  camo
   capistrano (= 3.14.1)
   capistrano-bundler
   capistrano-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,10 +27,15 @@ module ApplicationHelper
     end
   end
 
-  # returns camo url only in production mode
-  def camo_url(url)
-    if Rails.env.production? && /http:\/\// =~ url 
-      camo(url)
+  # returns proxy url only in production mode
+  def proxy(url)
+    key = ENV["IMAGEPROXY_KEY"]
+    host = ENV["IMAGEPROXY_HOST"]
+
+    if key && host
+      digest = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, url)
+      signature = Base64.urlsafe_encode64(digest).strip()
+      "#{host}/s#{signature}/#{url}"
     else
       url
     end

--- a/app/views/cards/_horizontal.html.slim
+++ b/app/views/cards/_horizontal.html.slim
@@ -4,7 +4,7 @@
 div id="collapseHorizontal#{link.id}" class="#{'collapse' if tags.any?}"
   = link_to link.url, target: '_blank', class: 'card my-1' do
     - if link.image?
-      img.card-img-top.h-100 loading='lazy' src = camo_url(link.image) height = link&.image_height width = link&.image_width
+      img.card-img-top.h-100 loading='lazy' src = proxy(link.image) height = link&.image_height width = link&.image_width
     .card-body
       h5.card-title = link.title
       p.card-text = link.description

--- a/app/views/cards/_vertical.html.slim
+++ b/app/views/cards/_vertical.html.slim
@@ -6,7 +6,7 @@ div id="collapseVertical#{link.id}" class="#{'collapse' if tags.any?}"
     .row.no-gutters.align-items-center
       - if link.image?
         .col-md-6.p-0
-          img.card-img.h-100 loading='lazy' src = camo_url(link.image) width=link&.image_width height = link&.image_height
+          img.card-img.h-100 loading='lazy' src = proxy(link.image) width=link&.image_width height = link&.image_height
       .col.p-0
         .card-body
           h5.card-title = link.title

--- a/config/initializers/camo.rb
+++ b/config/initializers/camo.rb
@@ -1,4 +1,0 @@
-if Rails.env.production?
-  ENV["CAMO_HOST"] = Rails.application.credentials.camo[:host]
-  ENV["CAMO_KEY"] = Rails.application.credentials.camo[:key]
-end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: willnorris/imageproxy
     ports:
       - "8080:8080"
-    command: -addr 0.0.0.0:8080 -cache memory:200:4h -signatureKey "secret"
+    command: -addr 0.0.0.0:8080 -cache memory:200:4h -signatureKey ${IMAGEPROXY_KEY:-"secret"}
 
 volumes:
   bundle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ services:
       - "database:/var/lib/mysql"
     command: --default-authentication-plugin=mysql_native_password
 
+  imageproxy:
+    image: willnorris/imageproxy
+    ports:
+      - "8080:8080"
+    command: -addr 0.0.0.0:8080 -cache memory:200:4h -signatureKey "secret"
+
 volumes:
   bundle:
   node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       BUNDLE_PATH: vendor/bundle
       MYSQL_HOST: db
       HOST: 0.0.0.0
+      IMAGEPROXY_KEY: ${IMAGEPROXY_KEY:-secret}
+      IMAGEPROXY_HOST: ${IMAGEPROXY_HOST:-http://localhost:8080}
     depends_on:
       - db
     ports:


### PR DESCRIPTION
試してみたら結構簡単に出来たのでとりあえずPRを投げておく

とりあえずメモリに200MB、最大4時間のキャッシュをする設定にしてみたけど、たぶん調整が必要
- README見てたらメモリの他にディスクとかs3とか、更にオープンソースなs3のクローンも使えるみたい

secretkeyに関してはRailsが入ってないコンテナから読む必要があるので、(開発時用のデフォルト値へのフォールバックありで)環境変数経由で渡すか、(実装がめんどくさそうだけど)やろうと思えばcredentials.yml.encから読み出すこともできるかもしれない（方針が決まったら対応する）
- docker内に入れてしまうから開発環境でも使えることには使えるけど、アクセスするアドレスが一定ではないから注入するのが大変そう（デフォルトでlocalhostにしておいてrails起動時の環境変数で変えられるようにするとか？）

URLを生成するコード(どこに書くのが正解か分からなかった)：
```rb
require 'openssl'
require 'base64'

KEY = "secret"
HOST = "http://localhost:8080"

def proxy(url)
  digest = OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), KEY, url)
  signature = Base64.urlsafe_encode64(digest).strip()
  "#{HOST}/s#{signature}/#{url}"
end
```