### PR TITLE
開発環境のMySQLのバージョンを本番環境に合わせる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     
     services:
       mysql:
-        image: mysql:5.7 # may need to change
+        image: mysql:5.7.30
         options: --health-cmd "mysqladmin ping -h localhost" --health-interval 20s --health-timeout 10s --health-retries 10
         ports:
           - 3306:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: /bin/sh -c "bundle exec rails s"
 
   db:
-    image: mysql
+    image: mysql:5.7.30
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:


### PR DESCRIPTION
# やったこと

- 開発環境 (Docker) やテスト (GitHub Actions) で使うMySQLのバージョンを、<del>README</del> https://github.com/nuita/nuita/pull/261#issuecomment-699986288 にあるバージョンに合わせました
  - `image` にtagを指定しないと `mysql:latest` が使われて、開発環境のDBだけどんどんバージョンアップしてしまう気がする
    - [MySQL 8.0はメンテナンスバージョンアップにがんがん機能追加・削除を入れてくる](https://speakerdeck.com/yoku0825/mysql-8-dot-0nifu-kenaitesutofalsezuo-rifang-jia?slide=15)という話もある
    - 本番と開発環境で挙動が違うと難しいのでできるだけ環境を揃えたい
  - テストだけMySQL 5.7を使ってた

# 動作確認方法

- docker-compose.yml
  - Dockernizeされた開発環境を初期化して `docker-compose run --rm app rails test` が通る
- GitHub Actions
  - CIのテストが通る

# ご相談

- READMEに書いてある各種アプリケーションのバージョンが本番環境のものなのか、推奨環境がこうなっているのか分かりませんでした。ひとまず本番環境のバージョンだと思ってcommit messageを書きましたが、もし違っていたらご指摘いただきたいです
  - そのようにcommit messageを修正します