### PR TITLE
ランディングページのはみ出しを修正

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -194,7 +194,7 @@ a {
 #landingContainer {
   background-image: url(<%= asset_path("landing_background") %>);
   min-height: 820px;
-  width: 100vw;
+  width: 100%;
   background-size: cover;
   background-color: rgba(0, 0, 40, 0.4)
 }


### PR DESCRIPTION
`width: 100vw;`を使うとスクロールバーを考慮せずにはみ出してしまう
でもなんで今ままで気づかなかったんだろう。特に直近の変更なさそうだったし