### PR TITLE
font-awesomeの指定を一時的にCSSに戻す

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,10 +18,10 @@ html
     = favicon_link_tag('favicon.ico')
     link rel="manifest" href="/manifest.json"
     link rel="apple-touch-icon" href="#{asset_url('logomark_color.png')}"
+    link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.0/css/all.css" integrity="sha384-OLYO0LymqQ+uHXELyx93kblK5YIS3B2ZfLGBmsJaUyor7CpMTBsahDHByqSuWW+q" crossorigin="anonymous"
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag 'application', defer: 'defer'
     = javascript_pack_tag 'application', defer: 'defer'
-    = javascript_include_tag 'https://use.fontawesome.com/releases/v5.0.6/js/all.js', defer: 'defer'
     = analytics_init if Rails.env.production?
   body
     = render 'layouts/header'


### PR DESCRIPTION
Font Awesome5からデフォルトになったらしい(?)JS+SVG形式の利用を試してみたのですが、
いいねボタン押したときの処理が旧DOM構造に依存してたので、JS+SVG形式の利用は一旦差し戻します