### PR TITLE
fix always returns url

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,6 @@ module ApplicationHelper
     else
       url
     end
-    url
   end
 
   # https://github.com/FortAwesome/font-awesome-sass/blob/master/lib/font_awesome/sass/rails/helpers.rb


### PR DESCRIPTION
s3のuriを返そうとしてるところが後ろに余分にurlがあるせいで常に元のurlを返すようになってしまっています。