### PR TITLE
urlを除いたstatementの文字数を200文字までとする

### DIFF
--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -14,9 +14,9 @@ class Nweet < ApplicationRecord
 
   validates :user_id, presence: true
   validates :did_at, presence: true
-  validates :statement, length: {maximum: 100}
   validate :did_at_past?
   validate :have_enough_interval?, on: :create
+  validate :statement_under_max_length?
 
   default_scope -> { order(did_at: :desc) }
 
@@ -76,5 +76,15 @@ class Nweet < ApplicationRecord
   private
     def set_url_digest
       self.url_digest = SecureRandom.alphanumeric
+    end
+
+    def statement_under_max_length?
+      return unless statement
+
+      clone_statement = statement.dup
+      URI.extract(clone_statement).uniq.each { |url| clone_statement.gsub!(url, '') }
+      if clone_statement.length > 200
+        errors.add(:statement, " except URLs must be 200 characters or less")
+      end
     end
 end

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -2,7 +2,7 @@
   .row.mx-2.mx-md-0
     = f.button "おめでとうございます🎉🎉🎉🎉🎉", disabled: true, class: "btn btn-block btn-nuita mt-0"
   .row.mx-2.mx-md-0
-    = f.text_area :statement, maxlength: 100, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力', value: params[:text]
+    = f.text_area :statement, rows: 2, class: "statement-textbox form-control col", placeholder: '感想・使用したオカズを入力', value: params[:text]
   = f.hidden_field :did_at, value: @nweet.did_at
   .row.mx-2.mx-md-0
     = f.submit "投稿する！", class: "btn btn-block btn-nuita btn-edit wider-marginbottom"

--- a/db/migrate/20201031163754_unset_limit_of_statement_on_nweet.rb
+++ b/db/migrate/20201031163754_unset_limit_of_statement_on_nweet.rb
@@ -1,0 +1,10 @@
+class UnsetLimitOfStatementOnNweet < ActiveRecord::Migration[5.2]
+  def up
+    change_column :nweets, :statement, :text
+  end
+
+  def down
+    # DBに256文字以上のデータがある場合、rollbackできないので明示的に禁じる
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_23_153905) do
+ActiveRecord::Schema.define(version: 2020_10_31_163754) do
 
   create_table "badges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -88,7 +88,7 @@ ActiveRecord::Schema.define(version: 2020_08_23_153905) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "statement", limit: 255
+    t.text "statement"
     t.string "url_digest"
     t.datetime "latest_liked_time"
     t.index ["url_digest"], name: "index_nweets_on_url_digest", unique: true

--- a/test/models/nweet_test.rb
+++ b/test/models/nweet_test.rb
@@ -36,7 +36,7 @@ class NweetTest < ActiveSupport::TestCase
     @nweet.statement = nil
     assert @nweet.valid?
 
-    @nweet.statement = 'a' * 150
+    @nweet.statement = 'a' * 250
     assert_not @nweet.valid?
 
     @nweet.statement = '誰だ今の'
@@ -95,5 +95,15 @@ class NweetTest < ActiveSupport::TestCase
     link = nweet.links.first
 
     assert link.tags.exists?(name: 'pixiv')
+  end
+
+  test 'statement including urls is valid' do
+    statement = <<~message
+      https://github.com
+      #{'a'*195}
+      https://nuita.net
+    message
+    @nweet.statement = statement
+    assert @nweet.valid?
   end
 end


### PR DESCRIPTION
#202 の対応

DBで255文字制限されていた nweet.statement の制限を解除し、URLを抜いた statement の文字数が200文字より多ければサーバ側でバリデーションに引っかかるようにした。

URL含めた statement の文字数が256文字以上のレコードがDBにある状態だと `bundle exec rake db:rollback` はできなくなるので、明示的に例外を発生させるようした。