### PR TITLE
fix: ページ上端からさらに上スクロールしたときにヘッダー壊れる問題を修正

### DIFF
--- a/app/frontend/src/header.ts
+++ b/app/frontend/src/header.ts
@@ -48,12 +48,12 @@ export function hideHeaderWhileScrolling() {
   window.addEventListener("scroll", () => {
     let nowOffset = window.pageYOffset;
 
-    if (nowOffset >= lastOffset) {
+    if (nowOffset > 0 && nowOffset >= lastOffset) {
       navbar.classList.add("navbar-faded-out");
     } else {
       navbar.classList.remove("navbar-faded-out");
     }
 
-    lastOffset = Math.max(0, nowOffset);
+    lastOffset = nowOffset;
   });
 }


### PR DESCRIPTION
Safariとかの画面上に引っ張る動作によってヘッダー壊れてたみたいです。
ちゃんと検証してなかった……問題報告＆対応ありがとうございました。