### PR TITLE
Actionsでset-env使わないようにする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow runs in a dockerless situation for now!
 # Adding flows for docker environment would be really appreciated.
 
-name: Testing
+name: Test
 
 on:
   push:
@@ -34,10 +34,7 @@ jobs:
         path: node_modules
         key: yarn-${{ hashFiles('**/yarn.lock') }} 
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.2
     - name: Install dependencies


### PR DESCRIPTION
自分でうっかり書いてるのかと思ったけど、依存してるsetup-rubyが古いせいだった

ので常に最新版使うようにした（バージョン固定してる理由何かあったっけ・・・？）