### PR TITLE
close #292

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,8 @@ require:
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  Exclude:
+    - 'db/schema.rb'
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,9 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
   Exclude:
-    - 'db/schema.rb'
+    - bin/*
+    - db/schema.rb
+    - vendor/bundle/**/*
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :liked_nweets, through: :likes, source: :nweet
   mount_uploader :icon, IconUploader
 
-  validates :screen_name, presence: true, uniqueness: {case_sensitive: true}, length: {maximum: 20}
+  validates :screen_name, presence: true, uniqueness: {case_sensitive: false}, length: {maximum: 20}
   validates :screen_name, format: {with: /[0-9a-zA-Z_]/}
   validates :handle_name, length: {maximum: 30}
   validates :biography, length: {maximum: 30}

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -25,6 +25,14 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.valid?
   end
 
+  test 'user name should be unique (case insensitive)' do
+    new_user = User.new(screen_name: 'CHiKUWA', email: 'abcdefg@hijkl.com', password: 'abcdefgh')
+    assert_not new_user.valid?
+
+    new_user.screen_name = '_chikuwa_'
+    assert new_user.valid?
+  end
+
   test 'handle name should be valid' do
     @user.handle_name = 'a' * 100
     assert_not @user.valid?


### PR DESCRIPTION
ちゃんと元記事を読んだら、バリデーションの仕様が変わるというだけで、DBの照合順序自体は元からcase insensitiveでした。（手元＆本番SQL確認しましたが、どちらも元々そうだった）

なので、DBのunique制約は変わらないままだから、`unique: {case_insensitive: false}` ってやっちゃってよさそう。