### PR TITLE
new.js.slimとnweets/newの不整合を修正

### DIFF
--- a/app/views/nweets/_home_form.html.slim
+++ b/app/views/nweets/_home_form.html.slim
@@ -1,3 +1,3 @@
-.nweet-form#homeNweetForm
+.nweet-form
   = link_to t('ui.nweet'), new_nweet_path, remote: true, class: "btn btn-nweet btn-nweet-home"
 

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -1,4 +1,4 @@
-= form_with(model: @nweet, html: {class: 'new-nweet-form'}, local: true) do |f|
+= form_with(model: @nweet, html: {class: 'nweet-form'}, local: true) do |f|
   .new-nweet-form-top
     = t('ui.nweet')
   .new-nweet-form-bottom.px-2

--- a/app/views/nweets/new.html.slim
+++ b/app/views/nweets/new.html.slim
@@ -1,12 +1,12 @@
 - provide(:title, 'ヌイートを作成')
 
-.container-fluid
+.container-md
   .row
     .d-none.d-md-block.col-md-3
       = render 'users/user_info', {user: current_user}
-    .col.p-0
-      .wider-margintop
+    .col.col-main
+      #nweetFormWrapper
         = render 'nweets/new_form'
-        = render 'pages/timeline'
+      = render 'pages/timeline'
     .d-none.d-lg-block.col-lg-3
       = render 'pages/recommend'

--- a/app/views/nweets/new.js.slim
+++ b/app/views/nweets/new.js.slim
@@ -1,2 +1,2 @@
 | document.title = 'ヌイートを作成 | Nuita';
-| document.getElementById('homeNweetForm').innerHTML = '#{j render 'nweets/new_form'}';
+| document.getElementById('nweetFormWrapper').innerHTML = '#{j render 'nweets/new_form'}';

--- a/app/views/pages/_user_home.html.slim
+++ b/app/views/pages/_user_home.html.slim
@@ -5,7 +5,8 @@
     .d-none.d-md-block.col-md-3
       = render 'users/user_info', {user: current_user}
     .col.col-main
-      = render 'nweets/home_form'
+      #nweetFormWrapper
+        = render 'nweets/home_form'
       = render 'pages/timeline'
     .d-none.d-lg-block.col-lg-3
       = render 'pages/recommend'


### PR DESCRIPTION
new.js.slimでnew_formを動的に挿入したときと、直接nweets/newを開いたときとで微妙にDOM構造が異なっていたため、余白やなんやに影響が出ていたので、new.js.slimのターゲットをformの外に出すことで解決します。