### PR TITLE
カラム崩れる問題を修正

### DIFF
--- a/app/assets/stylesheets/custom.scss.erb
+++ b/app/assets/stylesheets/custom.scss.erb
@@ -865,6 +865,7 @@ textarea {
 a.card {
   text-decoration: none;
   color: inherit;
+  line-break: anywhere;
 }
 
 /* contribution graph */


### PR DESCRIPTION
劇長い単語がカードに含まれてると幅足りなくなって崩れるっぽい