### PR TITLE
取得したオカズのテキストをバリデーション以下の文字数まで切り詰める

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -79,10 +79,10 @@ class Link < ApplicationRecord
     # Convert PanchiraResult to Link attributes
     def hash_panchira(panchira)
       {
-        title: panchira.title,
-        author: panchira.author,
-        circle: panchira.circle,
-        description: panchira.description,
+        title: panchira.title&.truncate(100),
+        author: panchira.author&.truncate(50),
+        circle: panchira.circle&.truncate(50),
+        description: panchira.description&.truncate(500),
         image: panchira.image.url,
         image_width: panchira.image.width,
         image_height: panchira.image.height,

--- a/app/views/cards/_horizontal.html.slim
+++ b/app/views/cards/_horizontal.html.slim
@@ -18,6 +18,6 @@ div id="collapseHorizontal#{link.id}" class="#{'collapse' if tags.any?}"
               = icon 'fas', 'users'
               span.pl-1.link-circle = link.circle
       - if link.description
-        p.card-text = link.description
+        p.card-text = link.description.truncate(200)
   - unless local_assigns[:genre_hidden?]
     = render 'cards/tags', link: link


### PR DESCRIPTION
そもそもモデル側での文字数制限いるか？という感じではある
一旦既存の制約に合わせてhash_panchiraで短くする処理を行い、view側でさらに切り詰めて使う