### PR TITLE
Nweet#includedを#relations_includedに改名

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
 
     def render_nweets(nweets, query)
       nweet_limit = 10
-      
+
       if params[:before]
         date = Time.zone.at(params[:before].to_i)
         @feed_items = nweets.relations_included.where(query, date).limit(nweet_limit)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   def tweet(content = render_tweet(current_user.autotweet_content))
     current_user.tweet(content)
-  rescue
+  rescue StandardError
     flash[:warning] = 'ツイートに失敗しました。Twitterアカウントの状態を確認してください。'
   end
 
@@ -16,23 +16,25 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:account_update, keys: [:handle_name, :screen_name, :icon, :autotweet_enabled, :autotweet_content, :biography])
     end
 
-    def current_user?(user)
+    def current_user?
       current_user == @user
     end
 
     # generate content of tweet from user-specific template
-    def render_tweet(nweet)
+    def render_tweet
       current_user.autotweet_content.gsub(/\[LINK\]/, nweet_url(@nweet))
     end
 
     def render_nweets(nweets, query)
+      nweet_limit = 10
+      
       if params[:before]
         date = Time.zone.at(params[:before].to_i)
-        @feed_items = nweets.included.where(query, date).limit(10)
+        @feed_items = nweets.relations_included.where(query, date).limit(nweet_limit)
         @before = @feed_items.last&.did_at&.to_i
         render partial: 'nweets/nweets'
       else
-        @feed_items = nweets.included.limit(10)
+        @feed_items = nweets.relations_included.limit(nweet_limit)
         @before = @feed_items.last&.did_at&.to_i
       end
     end

--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -20,7 +20,7 @@ class Nweet < ApplicationRecord
 
   default_scope -> { order(did_at: :desc) }
 
-  scope :included, -> { includes(:user, :nweet_links, links: :tags) }
+  scope :relations_included, -> { includes(:user, :nweet_links, links: :tags) }
 
   self.per_page = 10
 


### PR DESCRIPTION
タイムライン表示用に関連テーブルを一括読み込みするNweet#includedというスコープを用意していましたが、
Railsの名前と衝突しているという最悪の事態だったので適当にリネームしました。