### PR TITLE
application_controller.rb 周りのリファクタ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,9 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   USER_PER_PAGE = 20
 
-  def tweet(content = render_tweet(current_user.autotweet_content))
+  def tweet(content)
+    return if content.blank?
+
     current_user.tweet(content)
   rescue StandardError
     flash[:warning] = 'ツイートに失敗しました。Twitterアカウントの状態を確認してください。'
@@ -14,15 +16,6 @@ class ApplicationController < ActionController::Base
     def configure_permitted_parameters
       devise_parameter_sanitizer.permit(:sign_up, keys: [:handle_name, :screen_name, :icon])
       devise_parameter_sanitizer.permit(:account_update, keys: [:handle_name, :screen_name, :icon, :autotweet_enabled, :autotweet_content, :biography])
-    end
-
-    def current_user?
-      current_user == @user
-    end
-
-    # generate content of tweet from user-specific template
-    def render_tweet
-      current_user.autotweet_content.gsub(/\[LINK\]/, nweet_url(@nweet))
     end
 
     def render_nweets(nweets, query)

--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -20,7 +20,7 @@ class NweetsController < ApplicationController
     @nweet = current_user.nweets.build(new_nweet_params)
     if @nweet.save
       flash[:success] = 'ヌイートを投稿しました！'
-      tweet if current_user.autotweet_enabled
+      tweet(generate_tweet_content(@nweet)) if current_user.autotweet_enabled
     else
       flash[:danger] = @nweet.errors.full_messages
     end
@@ -67,5 +67,10 @@ class NweetsController < ApplicationController
     def correct_user
       @nweet = current_user.nweets.find_by(url_digest: params[:url_digest])
       redirect_to root_url if @nweet.nil?
+    end
+
+    # generate content of tweet from user-specific template
+    def generate_tweet_content(nweet)
+      current_user.autotweet_content.gsub(/\[LINK\]/, nweet_url(nweet))
     end
 end


### PR DESCRIPTION
[application_controllerの不具合？ #296](https://github.com/nuita/nuita/issues/296) の対応

### 1. 不要なメソッドの削除
https://github.com/nuita/nuita/blob/0266f222edc1f3f41d5e0917f8a3da40f57bb9f5/app/controllers/application_controller.rb#L19-L21

`current_user?` については使用されていないため削除

同様の
https://github.com/nuita/nuita/blob/0266f222edc1f3f41d5e0917f8a3da40f57bb9f5/app/helpers/users_helper.rb#L32-L34

についても使用されていないため削除しようかと思ったが、
1. 今回の対応範囲（application_controller.rb）ではないこと
2. helperメソッドならいつか使うかもしれないこと

から保留

### 2. ツイート内容生成周りのリファクタリング
nweetオブジェクトを元にツイート文を生成するメソッドの引数が使われていないとのことなので、その辺りの整理

- nweet オブジェクトを元にツイート文を生成するのでとりあえず nweets_controller.rb へ移動
- ツイート時に本文が `nil` または空の場合はツイッター側でエラーが出るはずなので、本文なしの場合はツイートを実行しないよう急場しのぎの対応

取り組んでいて気づいたが、`User.autotweet_content` が empty となることを許容しているのは問題かと思われる。
（ツイッターは本文なしで投稿するとエラーが出るはずなので）

別イシュー立てる等して対応したい。
