### PR TITLE
検索機能を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
     - vendor/bundle/**/*
     - node_modules/**/**/*
 
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,7 @@ Metrics/BlockLength:
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 163
+  Enabled: false
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,7 +16,11 @@ class PagesController < ApplicationController
   def explore
     @timeline = true
 
-    nweets = current_user&.global_feed || Nweet.global_feed
+    nweets = if params[:q]
+      Nweet.search(params[:q])
+    else
+      current_user&.global_feed || Nweet.global_feed
+    end
 
     render_nweets(nweets, 'did_at < ?')
   end

--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -83,6 +83,15 @@ class Nweet < ApplicationRecord
       count = rand([100, Nweet.where(featured: true).count].min)
       Nweet.where(featured: true).offset(count).first
     end
+
+    # 検索エンジン用意するまでの仮
+    def search(query)
+      if query
+        Nweet.left_outer_joins(links: :tags).where('nweets.statement LIKE ? OR tags.name LIKE ?', "%#{query}%", "%#{query}%").distinct
+      else
+        Nweet.all
+      end
+    end
   end
 
   private

--- a/app/views/pages/_landing.html.slim
+++ b/app/views/pages/_landing.html.slim
@@ -5,11 +5,11 @@
     .row.align-items-center
       .col
         h1.d-none.d-lg-block.landing-lead-h1 = t('.find_your_like_in_nuita')
-        = form_with url: '#', remote: true do |f|
+        = form_with url: explore_path, method: :get, local: true do |f|
           .input-group.landing-search-form-input
-            = f.search_field :query, {placeholder: t('.search.query.placeholder'), class: 'form-control', id: 'landingQueryInput'}
+            = f.search_field :q, {placeholder: t('.search.query.placeholder'), class: 'form-control', id: 'landingQueryInput'}
             .input-group-append
-              = f.button bi('search', 'search-icon'), type: :submit, class: 'btn btn-primary'
+              = f.button bi('search', 'search-icon'), name: nil, type: :submit, class: 'btn btn-primary'
         h6.mb-3 = t('.search_with_popular_tags')
         ul.popular-tags-list.mb-2
           - @tags.pluck(:name).each do |tag_name|

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -53,6 +53,6 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
 
     get explore_path(q: '男性受け')
     assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_tag)
-    assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_statements)
+    assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_statement)
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -46,4 +46,13 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     # assert_no_match user_path(@not_followee), response.body
     assert_select 'div.nweet-feed a[href=?]', user_path(@not_followee), count: 0
   end
+
+  test 'can search nweets in explore feed' do
+    nweet_with_tag = nweets(:featured)
+    nweet_with_statement = nweets(:femdom_statement)
+
+    get explore_path(q: '男性受け')
+    assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_tag)
+    assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_statements)
+  end
 end

--- a/test/fixtures/link_tags.yml
+++ b/test/fixtures/link_tags.yml
@@ -5,3 +5,7 @@ kanikama_is_r18g:
 kemo_is_kemo:
   link: kemo
   tag: kemo
+
+girls_form_is_femdom:
+  link: featured
+  tag: femdom

--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -11,5 +11,5 @@ kemo:
   title: 'あなたの…フレンズにしてください♪'
 
 featured:
-  url: 'https://www.dlsite.com/books/work/=/product_id/BJ280495.html'
-  title: 'Girls ForM 全巻パック'
+  url: 'https://www.dlsite.com/books/work/=/product_id/BJ064601.html'
+  title: 'Girls ForM Vol.10'

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -49,3 +49,9 @@ featured:
   url_digest: <%= SecureRandom.alphanumeric %>
   statement: 'https://www.dlsite.com/books/work/=/product_id/BJ280495.html'
   featured: true
+
+femdom_statement:
+  did_at: <%= 100.days.ago.utc %>
+  user: zoken
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: '男性受け最高'

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -13,3 +13,7 @@ scatoro:
 kemo:
   name: 'KEMO'
   censored_by_default: false
+
+femdom:
+  name: '男性受け'
+  censored_by_default: false


### PR DESCRIPTION
単純な検索機能を追加しました。SQLによる単純な検索で、タグとヌイートの本文にのみ対応しています。
半分ユーザーテストを兼ねているせいでなんちゃって検索みたいになっているので、
ちゃんと仕様が固まって動き始めた段階でElastic Searchとか専用の検索エンジンに置き換えようと思います。