### PR TITLE
文字数カウント機能を実装

### DIFF
--- a/app/frontend/css/components/navbars/_user_navbar.scss
+++ b/app/frontend/css/components/navbars/_user_navbar.scss
@@ -75,7 +75,7 @@
 
 .dropdown-toggle {
   color: $secondary-font-color;
-  padding-right: 0.5rem;
+  padding-right: 0;
 
   &:hover {
     color: $secondary-font-color;

--- a/app/frontend/css/nweets/_form.scss
+++ b/app/frontend/css/nweets/_form.scss
@@ -24,8 +24,23 @@
 .new-nweet-form-bottom {
   padding: 0.25rem 0.25rem 0.25rem 0;
   border-radius: 0 0 0.25rem 0.25rem;
-  text-align: right;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   background-color: $main-background-color;
+}
+
+.new-nweet-text-count {
+  padding-right: 1rem;
+  color: $secondary-font-color;
+}
+
+#nweetFormBottomTextLengthCount {
+  margin-right: 1px;
+}
+
+#nweetTextCountLimit {
+  font-size: small;
 }
 
 .explore-form-query-input {

--- a/app/frontend/packs/application.ts
+++ b/app/frontend/packs/application.ts
@@ -10,6 +10,7 @@ import setUserButtons from "../src/users";
 import setCalendar from "../src/calendar";
 import { setTagButtons } from "../src/tags";
 import { setAgeCheckModal } from "../src/age_check";
+import { setNewNweetForm } from "../src/new_nweet_form";
 
 import "../css/application.scss";
 
@@ -26,4 +27,5 @@ window.addEventListener("DOMContentLoaded", (event) => {
   setTagButtons();
   setAgeCheckModal();
   setCalendar();
+  setNewNweetForm();
 });

--- a/app/frontend/src/new_nweet_form.ts
+++ b/app/frontend/src/new_nweet_form.ts
@@ -1,0 +1,15 @@
+export function setNewNweetForm() {
+  const textarea = document.getElementById('newNweetFormTextarea');
+  if (textarea === null || !(textarea instanceof HTMLTextAreaElement)) {
+    return;
+  }
+
+  textarea.addEventListener('input', () => {
+    // ↓絵文字に配慮したコード。textboxの仕様を変えられたら使う
+    // const count = [...textarea.value].length.toString();
+    const count = textarea.value.length.toString();
+
+    const lengthCountDiv = document.getElementById('nweetFormBottomTextLengthCount');
+    lengthCountDiv.innerText = count;
+  });
+}

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -1,6 +1,10 @@
 = form_with(model: @nweet, html: {class: 'main-col-inner main-col-top new-nweet-form'}, local: true) do |f|
   .new-nweet-form-wrapper
-    = f.text_area :statement, maxlength: 100, rows: 2, class: 'new-nweet-form-textbox form-control', placeholder: t('.placeholder'), value: params[:text]
+    = f.text_area :statement, maxlength: 100, rows: 2, class: 'new-nweet-form-textbox form-control', id: 'newNweetFormTextarea', placeholder: t('.placeholder'), value: params[:text]
     = f.hidden_field :did_at, value: @nweet.did_at
     .new-nweet-form-bottom
-      = f.submit t('ui.nweet'), class: 'btn btn-primary rounded-pill'
+      .new-nweet-text-count.small
+        span#nweetFormBottomTextLengthCount 0
+        | /100
+      .new-nweet-form-submit-btn
+        = f.submit t('ui.nweet'), class: 'btn btn-primary rounded-pill'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       ]
     },
     "sourceMap": true,
-    "target": "es5"
+    "target": "es6"
   },
   "exclude": [
     "**/*.spec.ts",


### PR DESCRIPTION
<img width="1051" alt="スクリーンショット 2021-04-04 22 25 11" src="https://user-images.githubusercontent.com/19870474/113510199-a58b4b80-9594-11eb-974a-f8c3e5913766.png">

テキストボックスに文字数カウントを追加しました。
絵文字はサーバー側では1文字としてカウントされてますが、見ての通り2文字扱いを受けています。
これはRails側で生成されるフォームの仕様に合わせたためで、将来的にフォームのmaxlengthの挙動含め変更する必要がありそうです。

```<textarea maxlength="100" rows="2" class="new-nweet-form-textbox form-control" id="newNweetFormTextarea" placeholder="感想・使用したオカズを入力（100文字以内）" name="nweet[statement]"></textarea>```