### PR TITLE
featurableに関するテストで実URLへのアクセスをやめ、fixtureへと変更

### DIFF
--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -15,9 +15,14 @@ featured:
   url: 'https://www.dlsite.com/books/work/=/product_id/BJ064601.html'
   title: 'Girls ForM Vol.10'
   resolver: 'Panchira::DLsiteResolver'
+  image: 'https://fake-img.to-make-this-image-featurable.example.com'
 
 mesugaki:
   url: 'https://www.dlsite.com/books/work/=/product_id/BJ266236.html'
   title: '二次元コミックマガジン メスガキvs優しいお姉さんVol.1'
   resolver: 'Panchira::DLsiteResolver'
-  image: 'https://fake-img.to-make-this-image-featurable.example.com'
+  image: 'https://fake-img.this.should.be.featurable.too.example.com'
+
+image:
+  url: 'http://dokidokivisual.com/img/top/main_img.jpg'
+  resolver: 'Panchira::ImageResolver'

--- a/test/fixtures/links.yml
+++ b/test/fixtures/links.yml
@@ -5,6 +5,7 @@ kanikama:
   image: 'https://pixiv.cat/59554738-1.jpg'
   image_width: 700
   image_height: 480
+  resolver: 'Panchira::PixivResolver'
 
 kemo:
   url: 'https://twitter.com/aoi_nishimata/status/831825876899635200'
@@ -13,3 +14,10 @@ kemo:
 featured:
   url: 'https://www.dlsite.com/books/work/=/product_id/BJ064601.html'
   title: 'Girls ForM Vol.10'
+  resolver: 'Panchira::DLsiteResolver'
+
+mesugaki:
+  url: 'https://www.dlsite.com/books/work/=/product_id/BJ266236.html'
+  title: '二次元コミックマガジン メスガキvs優しいお姉さんVol.1'
+  resolver: 'Panchira::DLsiteResolver'
+  image: 'https://fake-img.to-make-this-image-featurable.example.com'

--- a/test/fixtures/nweet_links.yml
+++ b/test/fixtures/nweet_links.yml
@@ -9,3 +9,7 @@ two:
 three:
   nweet: featured
   link: featured
+
+four:
+  nweet: not_yet_featured
+  link: mesugaki

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -50,6 +50,13 @@ featured:
   statement: 'https://www.dlsite.com/books/work/=/product_id/BJ280495.html'
   featured: true
 
+not_yet_featured:
+  did_at: <%= 9.hours.ago.utc %>
+  user: emiya
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: 'https://www.dlsite.com/books/work/=/product_id/BJ268322.html'
+  featured: false
+
 femdom_statement:
   did_at: <%= 100.days.ago.utc %>
   user: zoken

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -9,9 +9,12 @@ class LikeTest < ActiveSupport::TestCase
   end
 
   test 'user can like nweet only once' do
+    assert_nil @nweet.latest_liked_time
+
     # user can like
     like = @user.likes.create!(nweet: @nweet)
     assert @user.liked?(@nweet)
+    assert @nweet.latest_liked_time > 1.minute.ago
 
     # but not twice
     another_like = @user.likes.build(nweet: @nweet)
@@ -35,16 +38,10 @@ class LikeTest < ActiveSupport::TestCase
     end
   end
 
-  test 'update liked nweet status' do
-    featurable_url = 'https://www.melonbooks.co.jp/detail/detail.php?product_id=537453&adult_view=1'
-    nweet = @user.nweets.create(did_at: Time.zone.now, statement: "👍 #{featurable_url}")
-
-    assert_nil nweet.latest_liked_time
-    assert_not nweet.featured?
+  test 'like makes nweet featurable' do
+    nweet = nweets(:not_yet_featured)
 
     first_like = @user.likes.create!(nweet: nweet)
-
-    assert nweet.latest_liked_time > 1.minute.ago
     assert nweet.featured?
 
     second_like = @other_user.likes.create!(nweet: nweet)

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -70,17 +70,20 @@ class LinkTest < ActiveSupport::TestCase
     assert_not link.legal?
 
     # 画像直リンもおすすめには出さない。個人的にはおすすめです
-    link = Link.fetch_from('http://dokidokivisual.com/img/top/main_img.jpg')
+    link = links(:image)
     assert_not link.legal?
 
-    # TODO: Resolverで取得してるけど画像がないテストケースを追加する
-
-    # og:imageつきの良いやつ
-    link = Link.fetch_from('https://www.dlsite.com/maniax/work/=/product_id/RJ315784.html')
+    # og:imageつきでDLSiteから取得してるいい感じのやつ
+    link = links(:mesugaki)
     assert link.legal?
     assert link.featurable?
 
-    # R-18Gとかcensored_by_defaultなタグつけるとダメになる
+    image = link.image
+    link.image = nil
+    assert link.legal?
+    assert_not link.featurable?
+
+    link.image = image
     link.set_tag('R-18G')
     assert link.legal?
     assert_not link.featurable?


### PR DESCRIPTION
`like_test.rb`, `link_test.rb` にあるfeaturableに関するテストで実URLへのアクセスをやめ、fixtureへと変更しました。
Github上での実URL取得がうまく行ってないのか、手元で成功していもたびたびテストが失敗していたためです。

本来外部URLへのアクセスは全部mockなりfixtureなりに置き換えたほうがいいかとは思うんですが、
それはそれで外部との接続の層のテストができないので恐ろしいです。
「外部へアクセスできる」程度のものだけ数を絞って置いておこうと思います。