### PR TITLE
モーダル表示時にbody直下にノードを移す

### DIFF
--- a/app/frontend/packs/application.ts
+++ b/app/frontend/packs/application.ts
@@ -14,6 +14,7 @@ import { setAgeCheckModal } from "../src/age_check";
 import { setNewNweetForm } from "../src/new_nweet_form";
 import { setSettingsMenu } from "../src/settings";
 import { setToasts } from "../src/toasts";
+import { setTagsModal } from "../src/modal";
 
 import "../css/application.scss";
 
@@ -35,4 +36,5 @@ window.addEventListener("DOMContentLoaded", (event) => {
   setNewNweetForm();
   setSettingsMenu();
   setToasts();
+  setTagsModal();
 });

--- a/app/frontend/src/modal.ts
+++ b/app/frontend/src/modal.ts
@@ -1,0 +1,16 @@
+// sidesectionのモーダルはposition: fixedの親要素の下にあるので、
+// モーダル表示時にだけbodyの直下にモーダル本体を移すことで問題に対処する
+export function setTagsModal() {
+  const buttons = document.getElementsByClassName('edit-modal-toggle-btn');
+  Array.from(buttons).forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const target = btn.getAttribute('data-bs-target');
+      const modal = document.getElementById(target.slice(1));
+
+      document.body.appendChild(modal);
+      modal.addEventListener('hidden.bs.modal', () => {
+        document.body.removeChild(modal);
+      });
+    });
+  });
+}

--- a/app/views/cards/_tags.html.slim
+++ b/app/views/cards/_tags.html.slim
@@ -5,6 +5,6 @@
         span.small = icon 'fas', 'hashtag'
         span = tag_name
   - if user_signed_in?
-    .tags-list-item.badge.bg-primary.rounded-pill.edit-modal-toggle-btn data-toggle="modal" data-target="#cardEditModal#{link.id}"
+    .tags-list-item.badge.bg-primary.rounded-pill.edit-modal-toggle-btn data-bs-toggle="modal" data-bs-target="#cardEditModal#{link.id}"
       span.small.edit-modal-toggle-btn-bi = bi 'pencil-fill'
     = render 'cards/edit_modal', link: link


### PR DESCRIPTION
Bootstrapのモーダルはposition: fixed; とかの親要素の下だと正常に動かないようなので、モーダルの表示時にだけ動的にbody直下にノードを移し替えることにしました。
モーダルの閉じるボタンが動かない問題もひそかに発見してたんですが、この修正で問題なく動くようになってそう。

https://stackoverflow.com/questions/10636667/bootstrap-modal-appearing-under-background