### PR TITLE
ヌイートの文字数制限を最大200文字に変更

### DIFF
--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -14,7 +14,7 @@ class Nweet < ApplicationRecord
 
   validates :user_id, presence: true
   validates :did_at, presence: true
-  validates :statement, length: {maximum: 100}
+  validates :statement, length: {maximum: 200}
   validate :past?
   validate :has_enough_interval?, on: :create
 

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -1,10 +1,10 @@
 = form_with(model: @nweet, html: {class: 'main-col-inner main-col-top new-nweet-form'}, local: true) do |f|
   .new-nweet-form-wrapper
-    = f.text_area :statement, maxlength: 100, rows: 2, class: 'new-nweet-form-textbox form-control', id: 'newNweetFormTextarea', placeholder: t('.placeholder'), value: params[:text]
+    = f.text_area :statement, maxlength: 200, rows: 2, class: 'new-nweet-form-textbox form-control', id: 'newNweetFormTextarea', placeholder: t('.placeholder'), value: params[:text]
     = f.hidden_field :did_at, value: @nweet.did_at
     .new-nweet-form-bottom
       .new-nweet-text-count.small
         span#nweetFormBottomTextLengthCount 0
-        | /100
+        | /200
       .new-nweet-form-submit-btn
         = f.submit t('ui.nweet'), class: 'btn btn-primary rounded-pill'

--- a/db/migrate/20210529135837_change_nweet_statement_length.rb
+++ b/db/migrate/20210529135837_change_nweet_statement_length.rb
@@ -1,0 +1,10 @@
+class ChangeNweetStatementLength < ActiveRecord::Migration[6.0]
+  def up
+    change_column :nweets, :statement, :string, limit: 200
+  end
+
+  def down
+    # DBに100文字より長いデータがある場合は失敗する
+    change_column :nweets, :statement, :string, limit: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_030222) do
+ActiveRecord::Schema.define(version: 2021_05_29_135837) do
 
   create_table "badges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 2021_02_20_030222) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "statement"
+    t.string "statement", limit: 200
     t.string "url_digest"
     t.datetime "latest_liked_time"
     t.boolean "featured", default: false, null: false

--- a/test/models/nweet_test.rb
+++ b/test/models/nweet_test.rb
@@ -36,7 +36,7 @@ class NweetTest < ActiveSupport::TestCase
     @nweet.statement = nil
     assert @nweet.valid?
 
-    @nweet.statement = 'a' * 150
+    @nweet.statement = 'a' * 250
     assert_not @nweet.valid?
 
     @nweet.statement = '誰だ今の'


### PR DESCRIPTION
close: #202

ユーザーアンケートの結果でも文字数制限がストレスになってそうな気配があったので、一旦200文字までに変更します。