### PR TITLE
過去の日時を指定してヌイートできるようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,13 +19,16 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:account_update, keys: [:handle_name, :screen_name, :icon, :autotweet_enabled, :autotweet_content, :biography])
     end
 
-    def render_nweets(nweets, query)
+    def render_nweets(nweets, query, order_by_created_at: false)
       @feed_items = nweets.relations_included.limit(NWEET_PER_PAGE)
 
       if params[:before]
         date = Time.zone.at(params[:before].to_i)
         @feed_items = @feed_items.where(query, date)
       end
+
+      # 通常射精時刻順に並ぶが、タイムラインのみヌイートの作成順に並ぶ
+      @feed_items = @feed_items.reorder(created_at: :desc) if order_by_created_at
 
       # 遅延評価のためfeed_itemsが確定してから算出
       @before = @feed_items.last&.did_at&.to_i

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   USER_PER_PAGE = 20
+  NWEET_PER_PAGE = 10
 
   def tweet(content)
     return if content.blank?
@@ -19,17 +20,17 @@ class ApplicationController < ActionController::Base
     end
 
     def render_nweets(nweets, query)
-      nweet_limit = 10
+      @feed_items = nweets.relations_included.limit(NWEET_PER_PAGE)
 
       if params[:before]
         date = Time.zone.at(params[:before].to_i)
-        @feed_items = nweets.relations_included.where(query, date).limit(nweet_limit)
-        @before = @feed_items.last&.did_at&.to_i
-        render partial: 'nweets/nweets'
-      else
-        @feed_items = nweets.relations_included.limit(nweet_limit)
-        @before = @feed_items.last&.did_at&.to_i
+        @feed_items = @feed_items.where(query, date)
       end
+
+      # 遅延評価のためfeed_itemsが確定してから算出
+      @before = @feed_items.last&.did_at&.to_i
+
+      render partial: 'nweets/nweets' if params[:before]
     end
 
     def render_users(users, template)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
       @nweet = current_user.nweets.build
       @timeline = true
 
-      render_nweets(current_user.timeline, 'did_at < ?')
+      render_nweets(current_user.timeline, 'did_at < ?', order_by_created_at: true)
     else
       @tags = Tag.where(featured: true)
     end

--- a/app/frontend/css/nweets/_form.scss
+++ b/app/frontend/css/nweets/_form.scss
@@ -22,25 +22,66 @@
 }
 
 .new-nweet-form-bottom {
-  padding: 0.25rem 0.25rem 0.25rem 0;
+  padding: 0.25rem 0.25rem 0.25rem 0.75rem;
   border-radius: 0 0 0.25rem 0.25rem;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   background-color: $main-background-color;
+  color: $secondary-font-color;
+}
+
+.new-nweet-form-bottom-left {
+  flex-grow: 1;
+  margin-left: 0;
+}
+
+.new-nweet-form-clock-icon {
+  margin-right: 0.5rem;
+  position: relative;
+  top: -0.1em;
 }
 
 .new-nweet-text-count {
-  padding-right: 1rem;
-  color: $secondary-font-color;
+  padding-right: 1rem; 
+}
+
+#newNweetDatetimePrompt {
+  display: flex;
+  align-items: center;
+}
+
+.new-nweet-datetime-group {
+  button {
+    background-color: none;
+    color: $secondary-font-color;
+    border: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.875rem;
+
+    &:hover {
+      text-decoration: underline;
+      color: inherit;
+
+      .new-nweet-datetime-prompt-message {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+.new-nweet-datetime-form-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.new-nweet-datetime-form {
+  max-width: 12em;
+  margin-right: 1rem;
 }
 
 #nweetFormBottomTextLengthCount {
   margin-right: 1px;
-}
-
-#nweetTextCountLimit {
-  font-size: small;
 }
 
 .explore-form-query-input {

--- a/app/frontend/css/nweets/_form.scss
+++ b/app/frontend/css/nweets/_form.scss
@@ -76,12 +76,18 @@
 }
 
 .new-nweet-datetime-form {
-  max-width: 12em;
+  width: fit-content;
+  font-size: small;
   margin-right: 1rem;
 }
 
 #nweetFormBottomTextLengthCount {
   margin-right: 1px;
+}
+
+#newNweetDatetimeFormCloseBtn {
+  width: 0.65em;
+  height: 0.65em;
 }
 
 .explore-form-query-input {

--- a/app/frontend/css/nweets/_form.scss
+++ b/app/frontend/css/nweets/_form.scss
@@ -76,18 +76,32 @@
 }
 
 .new-nweet-datetime-form {
-  width: fit-content;
   font-size: small;
-  margin-right: 1rem;
+  width: fit-content;
+  min-width: 12em;
 }
 
 #nweetFormBottomTextLengthCount {
   margin-right: 1px;
 }
 
-#newNweetDatetimeFormCloseBtn {
+button#newNweetDatetimeFormCloseBtn {
   width: 0.65em;
   height: 0.65em;
+  margin: 0 1rem;
+  line-height: 1em;
+
+  position: relative;
+
+  background: none;
+  border: none;
+
+  .bi-x {
+    display: inline-block;
+    position: absolute;
+    top: -0.25em;
+    left: -0.3em;
+  }
 }
 
 .explore-form-query-input {

--- a/app/frontend/css/nweets/_nweet.scss
+++ b/app/frontend/css/nweets/_nweet.scss
@@ -48,6 +48,10 @@ a.nweet-screen-name {
   color: $secondary-font-color;
 }
 
+.nweet-sub-info {
+  color: $secondary-font-color;
+}
+
 .nweet-statement {
   word-break: break-all;
   padding-left: 0.5rem;

--- a/app/frontend/src/new_nweet_form.ts
+++ b/app/frontend/src/new_nweet_form.ts
@@ -1,4 +1,9 @@
 export function setNewNweetForm() {
+  setTextCount();
+  setDatetimeForm();
+}
+
+const setTextCount = () => {
   const textarea = document.getElementById('newNweetFormTextarea');
   if (textarea === null || !(textarea instanceof HTMLTextAreaElement)) {
     return;
@@ -13,3 +18,27 @@ export function setNewNweetForm() {
     lengthCountDiv.innerText = count;
   });
 }
+
+const setDatetimeForm = () => {
+  const prompt = document.getElementById('newNweetDatetimePrompt');
+  if (prompt === null || prompt === undefined) {
+    return;
+  }
+
+  const form = document.getElementById('newNweetDatetimeFormWrapper');
+
+  prompt.addEventListener('click', (e) => {
+    e.preventDefault();
+
+    form.classList.remove('d-none');
+    prompt.classList.add('d-none');
+  });
+
+  const closeButton = document.getElementById('newNweetDatetimeFormCloseBtn');
+  closeButton.addEventListener('click', (e) => {
+    e.preventDefault();
+
+    prompt.classList.remove('d-none');
+    form.classList.add('d-none');
+  });
+};

--- a/app/frontend/src/new_nweet_form.ts
+++ b/app/frontend/src/new_nweet_form.ts
@@ -26,9 +26,19 @@ const setDatetimeForm = () => {
   }
 
   const form = document.getElementById('newNweetDatetimeFormWrapper');
+  const dateInput = <HTMLFormElement>document.getElementById('newNweetDatetimeFormInput');
 
   prompt.addEventListener('click', (e) => {
     e.preventDefault();
+
+    const now = convertDateToDOMFormat(new Date());
+
+    // ugly but effective https://stackoverflow.com/a/31665235
+    const minDate = new Date(new Date().setDate(new Date().getDate() - 30));
+
+    dateInput.value = now;
+    dateInput.max = now;
+    dateInput.min = convertDateToDOMFormat(minDate);
 
     form.classList.remove('d-none');
     prompt.classList.add('d-none');
@@ -38,7 +48,15 @@ const setDatetimeForm = () => {
   closeButton.addEventListener('click', (e) => {
     e.preventDefault();
 
+    dateInput.value = null;
+    dateInput.max = null;
+    dateInput.min = null;
     prompt.classList.remove('d-none');
     form.classList.add('d-none');
   });
 };
+
+const convertDateToDOMFormat = (date: Date) => {
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+  return date.toISOString().slice(0, 16);
+}

--- a/app/helpers/nweets_helper.rb
+++ b/app/helpers/nweets_helper.rb
@@ -7,8 +7,8 @@ module NweetsHelper
     time > current_user.nweets.first.did_at + 3.minutes
   end
 
-  def delete_possible?(did_at, user)
-    did_at > 1.hour.ago && user == current_user
+  def delete_possible?(created_at, user)
+    created_at > 1.hour.ago && user == current_user
   end
 
   def likes_number(nweet)

--- a/app/models/nweet.rb
+++ b/app/models/nweet.rb
@@ -33,7 +33,7 @@ class Nweet < ApplicationRecord
   def has_enough_interval?
     return if user.nweets.count == 0 || did_at.nil?
 
-    if did_at < user.nweets.first.did_at + 3.minutes
+    if user.nweets.where(did_at: (did_at - 3.minutes)...did_at).any?
       errors.add(:did_at, ' has not enough interval')
     end
   end

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -12,7 +12,8 @@
           .new-nweet-datetime-form-wrapper#newNweetDatetimeFormWrapper.d-none
             = f.label class: 'form-label'
               = bi 'clock', classname: 'new-nweet-form-clock-icon'
-            = f.datetime_field :did_at, class: 'form-control new-nweet-datetime-form'
+            / 投稿ボタンが押された場合、jsによって現在時刻が挿入される
+            = f.datetime_field :did_at, value: @nweet.did_at, class: 'form-control new-nweet-datetime-form', id: 'newNweetDatetimeFormInput'
             button#newNweetDatetimeFormCloseBtn
               = bi 'x'
       .new-nweet-text-count.small

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -14,8 +14,7 @@
               = bi 'clock', classname: 'new-nweet-form-clock-icon'
             / 投稿ボタンが押された場合、jsによって現在時刻が挿入される
             = f.datetime_field :did_at, value: @nweet.did_at, class: 'form-control new-nweet-datetime-form', id: 'newNweetDatetimeFormInput'
-            button#newNweetDatetimeFormCloseBtn
-              = bi 'x'
+            button.btn-close.small#newNweetDatetimeFormCloseBtn aria-label='Close'
       .new-nweet-text-count.small
         span#nweetFormBottomTextLengthCount 0
         | /200

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -13,8 +13,9 @@
             = f.label class: 'form-label'
               = bi 'clock', classname: 'new-nweet-form-clock-icon'
             / 投稿ボタンが押された場合、jsによって現在時刻が挿入される
-            = f.datetime_field :did_at, value: @nweet.did_at, class: 'form-control new-nweet-datetime-form', id: 'newNweetDatetimeFormInput'
-            button.btn-close.small#newNweetDatetimeFormCloseBtn aria-label='Close'
+            = f.datetime_field :did_at, value: @nweet.did_at, class: 'form-control new-nweet-datetime-form', id: 'newNweetDatetimeFormInput', size: '1'
+            button.small#newNweetDatetimeFormCloseBtn aria-label='Close'
+              = bi 'x'
       .new-nweet-text-count.small
         span#nweetFormBottomTextLengthCount 0
         | /200

--- a/app/views/nweets/_new_form.html.slim
+++ b/app/views/nweets/_new_form.html.slim
@@ -3,6 +3,18 @@
     = f.text_area :statement, maxlength: 200, rows: 2, class: 'new-nweet-form-textbox form-control', id: 'newNweetFormTextarea', placeholder: t('.placeholder'), value: params[:text]
     = f.hidden_field :did_at, value: @nweet.did_at
     .new-nweet-form-bottom
+      .new-nweet-form-bottom-left.small
+        .form-group.new-nweet-datetime-group          
+          #newNweetDatetimePrompt
+            button.btn.new-nweet-datetime-prompt
+              = bi 'clock', classname: 'new-nweet-form-clock-icon'
+              span.new-nweet-datetime-prompt-message = t('.designate_time')
+          .new-nweet-datetime-form-wrapper#newNweetDatetimeFormWrapper.d-none
+            = f.label class: 'form-label'
+              = bi 'clock', classname: 'new-nweet-form-clock-icon'
+            = f.datetime_field :did_at, class: 'form-control new-nweet-datetime-form'
+            button#newNweetDatetimeFormCloseBtn
+              = bi 'x'
       .new-nweet-text-count.small
         span#nweetFormBottomTextLengthCount 0
         | /200

--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -10,6 +10,9 @@ li.nweet id="nweet#{nweet.url_digest}"
         .content
           .nweet-sentence
             = t('.sentence', time: time_ago(nweet.did_at))
+            - if nweet.did_at != nweet.created_at
+              span.nweet-sub-info
+                = t('.posted', time: time_ago(nweet.created_at))
     .nweet-main
       - if nweet.links.any?
         = render 'cards/card', link: nweet.links.first

--- a/app/views/nweets/_nweet.html.slim
+++ b/app/views/nweets/_nweet.html.slim
@@ -23,7 +23,7 @@ li.nweet id="nweet#{nweet.url_digest}"
         - if user_signed_in?
           = render 'nweets/like_form', nweet: nweet
       .nweet-bottom-right
-        - if delete_possible?(nweet.did_at, nweet.user)
+        - if delete_possible?(nweet.created_at, nweet.user)
           = link_to nweet, method: :delete, class: "btn btn-no-outline nweet-bottom-btn", data: { confirm: t('.delete_confirmation') } do
             = bi 'trash'
         - unless @detail

--- a/config/locales/views/nweets/ja.yml
+++ b/config/locales/views/nweets/ja.yml
@@ -8,6 +8,7 @@ ja:
       is_nweeting_on_this_link: さんがヌイートしています
     new_form:
       placeholder: 感想・使用したオカズを入力
+      designate_time: 時刻を指定
     nweet:
       sentence: "%{time}にヌイートしました。"
       delete_confirmation: "一度削除したヌイートは復元できません。本当に削除しますか？"

--- a/config/locales/views/nweets/ja.yml
+++ b/config/locales/views/nweets/ja.yml
@@ -10,5 +10,6 @@ ja:
       placeholder: 感想・使用したオカズを入力
       designate_time: 時刻を指定
     nweet:
-      sentence: "%{time}にヌイートしました。"
+      sentence: "%{time}に射精しました。"
+      posted: "(%{time}に投稿)"
       delete_confirmation: "一度削除したヌイートは復元できません。本当に削除しますか？"

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -55,4 +55,13 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_tag)
     assert_select 'div.nweet-feed a[href=?]', nweet_path(nweet_with_statement)
   end
+
+  test 'scroll test' do
+    nweet = nweets(:chirstmas)
+    next_nweet = nweets(:eve)
+    before = nweet.did_at
+
+    get explore_path(before: before.to_i)
+    assert_select 'li.nweet a[href=?]', nweet_path(next_nweet)
+  end
 end

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -31,6 +31,12 @@ chirstmas:
   url_digest: <%= SecureRandom.alphanumeric %>
   statement: '😢'
 
+eve:
+  did_at: <%= Time.mktime(2017, 12, 24, 12).utc %>
+  user: chikuwa
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: 'good evening'
+
 r18g:
   did_at: <%= 3.days.ago.utc %>
   user: chikuwa

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -68,3 +68,10 @@ femdom_statement:
   user: zoken
   url_digest: <%= SecureRandom.alphanumeric %>
   statement: '男性受け最高'
+
+omoidashi:
+  did_at: <%= 1.weeks.ago.utc %>
+  created_at: <%= 10.seconds.ago.utc %>
+  url_digest: <%= SecureRandom.alphanumeric %>
+  statement: '思い出した'
+  user: shinji

--- a/test/fixtures/nweets.yml
+++ b/test/fixtures/nweets.yml
@@ -74,4 +74,4 @@ omoidashi:
   created_at: <%= 10.seconds.ago.utc %>
   url_digest: <%= SecureRandom.alphanumeric %>
   statement: '思い出した'
-  user: shinji
+  user: chikuwa

--- a/test/models/nweet_test.rb
+++ b/test/models/nweet_test.rb
@@ -96,4 +96,15 @@ class NweetTest < ActiveSupport::TestCase
 
     assert link.tags.exists?(name: 'pixiv')
   end
+
+  test 'nweet should have enough interval in did_at' do
+    @user.nweets.create(did_at: Time.zone.now - 1.minute)
+
+    nweet = @user.nweets.build(did_at: Time.zone.now)
+    assert_not nweet.valid?
+
+    @user.nweets.create!(did_at: 100.hours.ago)
+    nweet = @user.nweets.build(did_at: 100.hours.ago + 1.minute)
+    assert_not nweet.valid?
+  end
 end


### PR DESCRIPTION
close #29 

![スクリーンショット 2021-07-10 16 00 39](https://user-images.githubusercontent.com/19870474/125155002-fc0db480-e197-11eb-95a9-b20d553c07d1.png)

過去の日時を指定してヌイートできるようになりました。射精時刻は did_at, 投稿時刻は created_at として区別されます。この2つの時刻を区別しやすくするために、投稿時刻の表示もやや変更しました。

Chromeの開発者ツールで見ると小画面でフォームが崩れますが、実機では再現しなかったのでたぶんいけるやろの精神でPRを出します。