### PR TITLE
ユーザーの指定した射精時刻が3分以内の場合は投稿時刻と同一にする

### DIFF
--- a/app/controllers/nweets_controller.rb
+++ b/app/controllers/nweets_controller.rb
@@ -18,7 +18,7 @@ class NweetsController < ApplicationController
 
   def create
     @nweet = current_user.nweets.build(new_nweet_params)
-    @nweet.did_at ||= Time.zone.now
+    set_did_at
 
     if @nweet.save
       flash[:success] = t('toasts.nweet.post')
@@ -65,5 +65,12 @@ class NweetsController < ApplicationController
     # generate content of tweet from user-specific template
     def generate_tweet_content(nweet)
       current_user.autotweet_content.gsub(/\[LINK\]/, nweet_url(nweet))
+    end
+
+    # did_atが空か、指定された時刻が現在から3分以内の場合に現在時刻を挿入する
+    def set_did_at
+      if @nweet.did_at.nil? || @nweet.did_at > 3.minutes.ago
+        @nweet.did_at = Time.zone.now
+      end
     end
 end

--- a/test/controllers/nweets_controller_test.rb
+++ b/test/controllers/nweets_controller_test.rb
@@ -71,4 +71,11 @@ class NweetsControllerTest < ActionDispatch::IntegrationTest
     get recommend_path
     assert_response :success
   end
+
+  test 'did_at should be equal to created at if the diff is smaller than 3 minutes' do
+    login_as(@user)
+    post nweets_path, params: {nweet: {did_at: 1.minute.ago}}
+
+    assert_equal Nweet.first.created_at, Nweet.first.did_at
+  end
 end

--- a/test/models/badge_test.rb
+++ b/test/models/badge_test.rb
@@ -1,16 +1,16 @@
 require 'test_helper'
 
 class BadgeTest < ActiveSupport::TestCase
-  def setup
-    @badge = badges(:christmas)
-    @user = users(:chikuwa)
-  end
+  # def setup
+  #   @badge = badges(:christmas)
+  #   @user = users(:chikuwa)
+  # end
 
-  test 'can add and remove users' do
-    @badge.users << @user
-    assert @badge.users.exists?
+  # test 'can add and remove users' do
+  #   @badge.users << @user
+  #   assert @badge.users.exists?
 
-    @badge.users.destroy(@user)
-    assert_not @badge.users.exists?
-  end
+  #   @badge.users.destroy(@user)
+  #   assert_not @badge.users.exists?
+  # end
 end


### PR DESCRIPTION
間違って射精時刻の修正ボタンを押してしまい、投稿時刻とほぼ同じなのに注釈がついちゃってる投稿を何個か見つけたので実装しました。
ついでにバッジ機能のテストも削除しています（使い所ないので）